### PR TITLE
Adds all Ruby RFCs under text/ruby subdirectory

### DIFF
--- a/text/ruby/bundle-install/0000-template.md
+++ b/text/ruby/bundle-install/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you proposing to the buildpack?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/ruby/bundle-install/0001-dev-test-gems-during-build.md
+++ b/text/ruby/bundle-install/0001-dev-test-gems-during-build.md
@@ -1,0 +1,57 @@
+# Provide development/test gems during build phase
+
+## Proposal
+
+The buildpack should install and provide gems specified in the `development`
+and `test` groups in a layer that is made available to subsequent buildpacks
+during the build phase. The buildpack will also continue to exclude these
+`development` and `test` gems when providing a layer used for the `launch`
+phase.
+
+## Motivation
+
+While we want to ensure we only install "production" dependencies when we build
+the application image, there are cases where buildpacks subsequent to the
+`bundle-install` buildpack will want to invoke code provided by gems that are
+including in the `development` or `test` groups. In its current implementation,
+these buildpacks would error as none of those dependencies are provided during
+the build phase.
+
+## Implementation
+
+The buildpack will provide 2 different layers depending upon the metadata
+indicating what phases the gems will be required in. The implementation will
+follow these rules:
+
+1. If the `gems` build plan entry is required during `build`, then the
+   buildpack will create a layer with `build` and `cache` flags set to true.
+   Into this layer it will install all gems, including those in the
+   `development` and `test` groups.
+
+2. If the `gems` build plan entry is required during `launch`, then the
+   buildpack will create a layer with the `launch` flag set to true. Into this
+   layer it will install only those gems that are not in the `development` or
+   `test` groups.
+
+3. If the `gems` build plan entry is required during both `build` and `launch`,
+   then the buildpack will perform both of the steps outlined above.
+
+These layers will necessarily contain an overlapping set of gems. This is
+tolerable because the layers have different lifecycles, only being exposed to
+either the `build` or `launch` phases in a mutually exclusive relationship.
+
+The layers will also leverage build and launch environment variables to
+configure the location of the `BUNDLE_USER_CONFIG` environment variable to
+ensure the `bundle` CLI uses the correct gem set during each phase.
+
+### Performance Implications
+
+In the worst case, when the `gems` build plan entry is required during both
+`build` and `launch`, the buildpack will need to install many of the same gems
+twice. To prevent this from being a huge performance penalty, the buildpack
+will perform the following steps:
+
+1. Install all gems into the `build` layer.
+2. Copy all gems from the `build` layer into the `launch` layer.
+3. Execute the `launch` layer install process. This will remove those extra
+   `development` and `test` gems as the process will execute `bundle clean`.

--- a/text/ruby/passenger/0000-template.md
+++ b/text/ruby/passenger/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you proposing to the buildpack?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/ruby/passenger/0001-implementation.md
+++ b/text/ruby/passenger/0001-implementation.md
@@ -1,0 +1,22 @@
+# Passenger Buildpack Implementation
+
+## Proposal
+
+Create a Passenger implementation buildpack to allow for applications using
+Passenger to have an official workflow.
+
+## Motivation
+
+Currently, there is no support for Passenger applications in the Ruby language
+family. With the addition of a `passenger` buildpack, users would be able to
+start a Passenger application server using the Ruby buildpackage. Passenger is
+one of the [top four most popular web
+servers](https://www.ruby-toolbox.com/categories/web_servers) used within the
+Ruby community, so support for it could cover a large number of uses case.
+
+## Implementation
+
+Detection will pass is `passenger` is present in the `GEMFILE`.
+
+On detection, the buildpack will set the start command to be `bundle exec
+passenger start --port {$PORT:-3000}`.

--- a/text/ruby/rake/0000-template.md
+++ b/text/ruby/rake/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you proposing to the buildpack?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/ruby/rake/0001-rake-task.md
+++ b/text/ruby/rake/0001-rake-task.md
@@ -1,0 +1,74 @@
+# Rake Task Execution
+
+## Proposal
+
+Enable application developers to build images that execute `rake` tasks from a
+`Rakefile` at runtime.
+
+## Motivation
+
+[`rake`](https://ruby.github.io/rake/) is a very common script/task execution
+framework. Ruby developers will commonly write `rake` tasks to run tests,
+execute database migrations, or build release artifacts.
+
+Developers can declare named tasks in a `Rakefile` which can be executed by
+running `rake <task>`.  Additionally, `rake` supports the concept of a
+"default" task that will be run when simply executing `rake` by itself.
+
+The buildpack should support both of these forms of execution, opting to
+support the "default" task as the primary launch process.
+
+## Implementation
+
+Supporting the "default" case can be achieved by setting the launch process to
+`rake`. Therefore, when a developer executes their built image, the "default"
+task will be executed.
+
+Supporting the "specific" case, where an app developer wishes to execute a task
+that is not the default, the buildpack can leverage the [recent
+change](https://github.com/buildpacks/rfcs/blob/main/text/0045-launcher-arguments.md)
+in behavior of the launcher to support additional, user-provided arguments.
+
+For example, a user may build an application that contains the following `Rakefile`:
+
+```ruby
+task default: %w[greet]
+
+desc "Prints a greeting"
+task :greet, [:name] do |t, args|
+  args.with_defaults(:name => "World")
+  puts "Hello, #{args.name}!"
+end
+```
+
+In this case, the built container image will have a launch command of `rake`
+which will enable some useful workflows for the given image.
+
+For example, the user can execute the "default" task:
+
+```
+$ docker run -it <image>
+Hello, World!
+```
+
+Or list the tasks available in the `Rakefile`:
+
+```
+$ docker run -it <image> --tasks
+rake greet[name]  # Prints a greeting
+```
+
+Or execute a task by name:
+
+```
+$ docker run -it <image> greet[Alice]
+Hello, Alice!
+```
+
+### Bundler Support
+
+It is common for Ruby developers to use `bundler` for their applications, and
+we should ensure that the `rake` task executes with the gems specified in the
+`Gemfile`. Given this concern, the buildpack should modify the launch command
+to `bundle exec rake` if the source code contains a `Gemfile` and the `Gemfile`
+references `rake`.

--- a/text/ruby/rfcs/0000-template.md
+++ b/text/ruby/rfcs/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you purposing to the overall language family?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/ruby/rfcs/0001-web-server-buildpacks.md
+++ b/text/ruby/rfcs/0001-web-server-buildpacks.md
@@ -1,0 +1,113 @@
+# Ruby Webserver Support
+
+## Proposal
+
+The Ruby buildpack should support, by default, applications that use a Ruby webserver. Full support in this case will mean detecting a specific webserver is required and ensuring a start command for that server is set, along with requiring any needed dependencies for the launch phase. This last requirement is important as none of the mri, bundler, or bundle-install buildpacks will require their dependencies to be made available during launch. To begin with, we will support 5 ruby servers: thin, unicorn, rackup, puma, and passenger.
+
+## Motivation
+
+One of the primary use-cases for the Ruby buildpack will be to build applications that act as webservers. There are a number of webservers in the Ruby community that are in wide-use. We should enable support for these webservers by default while also allowing developers to override the start command to support their unique use-case.
+
+## Implementation
+
+The 5 webservers will be defined in order groupings that are mutually exclusive to one another as can be seen below:
+
+```toml
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.121"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.107"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.11"
+
+  [[order.group]]
+    id = "paketo-community/puma"
+    version = "0.0.3"
+
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.121"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.107"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.11"
+
+  [[order.group]]
+    id = "paketo-community/thin"
+    version = "0.0.3"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.121"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.107"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.11"
+
+  [[order.group]]
+    id = "paketo-community/unicorn"
+    version = "0.0.3"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.121"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.107"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.11"
+
+  [[order.group]]
+    id = "paketo-community/passenger"
+    version = "0.0.3"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.121"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.107"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.11"
+
+  [[order.group]]
+    id = "paketo-community/rackup"
+    version = "0.0.3"
+```
+
+Choosing to make these groups mutually exclusive to one another instead of as a single group with several optional webservers is to ensure that we only detect 1 webserver per build, and that we keep error messages as clear as possible.
+
+Only detecting a single webserver buildpack will ensure that we don't have confusing output, eg. an app that included both `unicorn` and `rack` in its Gemfile would cause both to the detect and both to set a start command, with an unclear output of which wins.
+
+Additionally, if an app were to not cause detection for any webserver with a single group that had optional webserver buildpacks, the error message does not clearly indicate that detection of a webserver is what failed. Instead, the lifecycle prints an error about unrequired dependencies. This type of error message is confusing to the user and should be avoided.
+

--- a/text/ruby/rfcs/0002-procfile.md
+++ b/text/ruby/rfcs/0002-procfile.md
@@ -1,0 +1,114 @@
+# Procfile Support
+
+## Proposal
+
+The [`Procfile` Buildpack](https://github.com/paketo-buildpacks/procfile/)
+should be added as an optional buildpack to the end of all order groups.
+
+## Motivation
+
+The use of a `Procfile` to manage multiple application processes is common in
+the Ruby community. Several
+[services](https://devcenter.heroku.com/articles/procfile) and
+[tools](https://github.com/ddollar/foreman) already have existing support for
+this file format. Optionally supporting `Procfile` will allow users to
+configure their processes using tools they are already comfortable with.
+
+## Implementation
+
+The `Procfile` buildpack will be added, optionally, as the last buildpack in
+each existing order group, as can be seen below:
+
+```toml
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.139"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.126"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.31"
+
+  [[order.group]]
+    id = "paketo-community/puma"
+    version = "0.0.22"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "1.3.9"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.139"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.126"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.31"
+
+  [[order.group]]
+    id = "paketo-community/thin"
+    version = "0.0.19"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "1.3.9"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.139"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.126"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.31"
+
+  [[order.group]]
+    id = "paketo-community/unicorn"
+    version = "0.0.17"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "1.3.9"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-community/mri"
+    version = "0.0.139"
+
+  [[order.group]]
+    id = "paketo-community/bundler"
+    version = "0.0.126"
+
+  [[order.group]]
+    id = "paketo-community/bundle-install"
+    version = "0.0.31"
+
+  [[order.group]]
+    id = "paketo-community/rackup"
+    version = "0.0.21"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "1.3.9"
+    optional = true
+```

--- a/text/ruby/rfcs/0003-buildpack-yml-to-env-var.md
+++ b/text/ruby/rfcs/0003-buildpack-yml-to-env-var.md
@@ -1,0 +1,58 @@
+# Buildpack.yml to Environment Variables
+
+## Proposal
+
+Migrate to using environment variables to do all buildpack configuration and
+get rid of `buildpack.yml`.
+
+## Motivation
+
+There are several reasons for making this switch.
+1. There is already an [existing RFC](https://github.com/paketo-buildpacks/rfcs/blob/b885abe5fe0b8f64def4a79f0952b7050f3bee6f/accepted/0003-replace-buildpack-yml.md) that proposes moving away from `buildpack.yml` as a configuration tool.
+1. Environment variables appears to be the standard for configuration in other
+   buildpack ecosystems such as Google Buildpacks and Heroku as well as the
+   Paketo Java buildpacks. Making this change will align the buildpack with the
+   rest of the buildpack ecosystem.
+1. There is native support to pass environment variables to the buildpack
+   either on a per run basis or by configuration that can be checked into
+   source control, in the form of `project.toml`.
+
+## Implementation
+The proposed environment variables for Ruby are as follow:
+
+#### BP_MRI_VERSION
+```shell
+$BP_MRI_VERSION="2.7.1"
+```
+This will replace the following structure in `buildpack.yml`:
+```yaml
+mri:
+  version: 2.7.1
+```
+
+#### BP_BUNDLER_VERSION
+```shell
+$BP_BUNDLER_VERSION="2.1.4"
+```
+This will replace the following structure in `buildpack.yml`:
+```yaml
+bundler:
+  version: "2.1.4"
+```
+
+### Deprecation Strategy
+In order to facilitate a smooth transition from `buildpack.yml`, the buildpack
+should will support both configuration options with environment variables
+taking priority or `buildpack.yml` until the 1.0 release of the buildpack. The
+buildpack will detect whether or not the application has a `buildpack.yml` and
+print a warning message which will include links to documentation on how to
+upgrade and how to run builds with environment variable configuration. After
+1.0, having a `buildpack.yml` will cause a detection failure and with a link to
+the same documentation. This behavior will only last until the next minor
+release of the buildpack after which point there will no longer be and error
+but `buildpack.yml` will not be supported.
+
+## Source Material
+* [Google buildpack configuration](https://github.com/GoogleCloudPlatform/buildpacks#language-idiomatic-configuration-options)
+* [Paketo Java configuration](https://paketo.io/docs/buildpacks/language-family-buildpacks/java)
+* [Heroku configuration](https://github.com/heroku/java-buildpack#customizing)

--- a/text/ruby/rfcs/0004-rails-assets.md
+++ b/text/ruby/rfcs/0004-rails-assets.md
@@ -1,0 +1,258 @@
+# Rails Asset Pipeline Support
+
+## Proposal
+
+Include a Rails assets buildpack in the Ruby buildpack family. The buildpack
+will be charged with precompiling assets so that they can be accessed in a
+production deployment. The buildpack will be included in each of the
+"webserver" buildpack groups, but not the Rake group. To support the buildpack
+build process, the `node-engine` buildpack will also be included in any group
+that includes the new buildpack.
+
+## Motivation
+
+[Rails](https://rubyonrails.org/) is a popular web framework used in the Ruby
+community. In recent versions of Rails, Javascript, CSS, and other front-end
+assets are managed in a build system called the [Asset
+Pipeline](https://guides.rubyonrails.org/asset_pipeline.html).
+
+Rails developers that use the Asset Pipeline will expect that their assets are
+precompiled and made available in the built image. This means that the Ruby
+buildpack groups should include a buildpack that executes this process to
+precompile assets when it is needed.
+
+## Implementation
+
+A new `rails-assets` buildpack will be developed to detect that the Rails Asset
+Pipeline is present, and then precompile those assets so that they can be
+included in the built image.
+
+### Detection Criteria
+
+The buildpack will detect if the `Gemfile` contains the `rails` gem and the
+`app/assets` directory is present. According to the
+[documentation](https://guides.rubyonrails.org/asset_pipeline.html#how-to-use-the-asset-pipeline),
+the `app/assets` directory is the location that a Rails application will expect
+to find assets that need to be compiled before a production deployment.
+
+If the buildpack detects, then it will need to require `node` since a Node.js
+runtime is required to execute the asset precompilation process.
+
+### Build Process
+
+The build process of the buildpack will execute a precompilation process that
+generates a set of assets to be served in a production deployment.  The
+[documentation](https://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets)
+outlines that assets can be precompiled by executing `bundle exec rails
+assets:precompile`.
+
+This choice means that we will only be supporting Rails >= 5.0. Rails versions
+prior to 5.0 used a Rake task to precompile assets with a command like `bundle
+exec rake assets:precompile`. It is reasonable to only support these more
+recent versions as Rails versions prior to 5.0 are [no longer
+supported](https://guides.rubyonrails.org/maintenance_policy.html) by the
+project.
+
+### Ruby Buildpack Order Grouping
+
+The `rails-assets` buildpack will be included in each of the "webserver"
+buildpack groups (`puma`, `thin`, `unicorn`, `passenger` and `rackup`). In each
+case, the buildpack will be marked as optional. The `rails-assets` buildpack
+**will not** be included in the `rake` order grouping. Immediately before the
+`rails-assets` buildpack, the `node-engine` buildpack will also be included as
+optional.
+
+Given these changes, the updated order grouping for the Ruby buildpack will
+look like the following:
+
+```toml
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/mri"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundler"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundle-install"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rails-assets"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/puma"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "<version>"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/mri"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundler"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundle-install"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rails-assets"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/thin"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "<version>"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/mri"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundler"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundle-install"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rails-assets"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/unicorn"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "<version>"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/mri"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundler"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundle-install"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rails-assets"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/passenger"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "<version>"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/mri"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundler"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundle-install"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rails-assets"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rackup"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "<version>"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/mri"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundler"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/bundle-install"
+    version = "<version>"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/rake"
+    version = "<version>"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "<version>"
+    optional = true
+```


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Moves the rfcs from the bundle-install, passenger, rake, and ruby repos into the `text/ruby` subdirectory.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
