### PR TITLE
Adds all Stacks RFCS under text/stacks subdirectory

### DIFF
--- a/text/stacks/rfcs/0000-template.md
+++ b/text/stacks/rfcs/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you proposing to the stacks?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/stacks/rfcs/0001-stack-package-metadata.md
+++ b/text/stacks/rfcs/0001-stack-package-metadata.md
@@ -1,0 +1,50 @@
+# Add io.paketo.stack.packages label
+
+## Proposal
+
+We want to add a new label (io.paketo.stack.packages) to all stacks that contains a collection of metadata for all of the packages in the stack.
+
+## Motivation
+
+This metadata will help users have a more accurate depiction of exactly what is in the stack.
+
+## Implementation
+
+
+Schema:
+```json
+"io.paketo.stack.packages": "[{
+                               "name": "<NAME>",
+                               "version": "<VERSION>>",
+                               "arch": "<ARCHITECTURE>>",
+                               "summary": "<SUMMARY>",
+                               "sourcePackage": {
+                                 "name": "<NAME>",
+                                 "version": "<VERSION>",
+                                 "upstreamVersion": "<UPSTREAM_VERSION>"
+                               }
+                            }]"
+```
+
+Example:
+```json
+"io.paketo.stack.packages": "[{
+                               "name": "libc6",
+                               "version": "2.27-3ubuntu1.4",
+                               "arch": "amd64",
+                               "summary": "GNU C Library: Shared libraries",
+                               "sourcePackage": {
+                                 "name": "glibc",
+                                 "version": "2.27-3ubuntu1.4",
+                                 "upstreamVersion": "2.27"
+                               }
+                             }]"
+```
+
+
+## Unresolved Questions and Bikeshedding
+
+Is there a clearer/more accurate label name we can use? Technically "stack" refers to a pair of images but we're only trying to represent the packages on a single image.
+
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Moves the rfcs from the stack repos into the text/stacks subdirectory as a part of #67

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
