### PR TITLE
Adds all Go RFCs under text/go subdirectory

### DIFF
--- a/text/go/0000-template.md
+++ b/text/go/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you proposing to the buildpack?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/go/dep-ensure/0001-ensure.md
+++ b/text/go/dep-ensure/0001-ensure.md
@@ -1,0 +1,82 @@
+# Ensure Command
+
+## Proposal
+
+The [Dep documentation](https://golang.github.io/dep/docs/daily-dep.html)
+outlines several commands for use, but the primary command invoked during
+normal use of the package manager is `dep ensure`.
+
+The `dep ensure` command will perform several tasks when it is invoked. The
+documentation describes this as follows:
+
+> Hey dep, please make sure that my project is in sync: that `Gopkg.lock`
+> satisfies all the imports in my project, and all the rules in `Gopkg.toml`, and
+> that `vendor/` contains exactly what `Gopkg.lock` says it should.
+
+Furthermore, it outlines that invoking `dep ensure` will bring the project into
+a stable state, which is ideal for the workings of this buildpack:
+
+> `dep ensure` is almost never the wrong thing to run; if you're not sure
+> what's going on, running it will bring you back to safety ("the nearest
+> lilypad"), or fail informatively.
+
+Given this information, this buildpack should invoke a package installation
+process that is the equivalent of the following shell script:
+
+```
+export GOPATH=[temporary directory]
+export DEPCACHEDIR=[layer directory]
+dep ensure
+```
+
+This process will be invoked from within the application source code directory.
+As a prerequisite for running this command, the buildpack will detect that the
+source code contains a `Gopkg.toml` file. Optionally, there may be a
+`Gopkg.lock` file that outlines specific versions of the dependencies to be
+packaged. The `dep ensure` command will automatically obey the contents of the
+`Gopkg.lock` file if it is present.
+
+After running `dep ensure` the application source code directory will be
+populated with a `vendor` directory containing the contents of all packages
+required by the application. If there was no `Gopkg.lock` file in the original
+source, that file would now exist with a populated set of version mappings for
+each dependency.
+
+The `vendor` directory will then be used to aid in the compilation of the
+program in the [`go-build`
+buildpack](https://github.com/paketo-buildpacks/go-build).
+
+### GOPATH
+
+The `dep` tool requires that the source code it operates on be located in a
+working GOPATH directory structure. As the lifecycle places the source code
+into a root `/workspace` directory, a GOPATH will need to be constructed and
+the source code copied to this new location before invoking the `dep ensure`
+command.
+
+Once the command successfully completes, the results of that invocation
+(`vendor` and `Gopkg.lock`) can be copied back into the original `/workspace`
+directory.
+
+### DEPCACHEDIR
+
+As outlined in the [`dep`
+glossary](https://golang.github.io/dep/docs/glossary.html#local-cache), the
+`dep` tool maintains a cache of upstream sources. This cache can be used to
+increase the performance of the `dep ensure` command by removing the need to
+make a network call to retrieve upstream source code before copying the
+required dependencies into the `vendor` directory.
+
+To support this performance boost, the buildpack will allocate a layer marked
+as `cache = true` in the Layer Content Metadata file so that the layer will be
+persisted to subsequent builds. Additionally, the path to this layer on disk
+will be assigned to the `$DEPCACHEDIR` environment variable and made available
+to the `dep ensure` command on invocation.
+
+## Motivation
+
+The primary case for executing the `dep ensure` command as outlined above is
+that it will bring the application to a safe checkpoint for the dependencies
+required. Additionally, including a cache via the `DEPCACHEDIR` environment
+variable will enable the buildpack to provide performant rebuilds of the
+dependencies provided.

--- a/text/go/go-build/0001-compilation.md
+++ b/text/go/go-build/0001-compilation.md
@@ -1,0 +1,123 @@
+# Compilation
+
+## Proposal
+
+The compilation mechanism for Go application source code will be the `go build`
+tool. This aligns with the
+[guidance](https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies) in
+the Go documentation.
+
+Specifically, source is compiled with the following command:
+
+```
+export GOCACHE=[layer directory]
+go build \
+  -o [output directory] \
+  -buildmode pie \
+  [-mod vendor] \
+  [targets]
+```
+
+### Output Directory
+The `go build` tool should output the compilation results to a specific output
+directory. From the Go documentation for `go build`:
+
+> The -o flag forces build to write the resulting executable or object to the
+> named output file or directory, instead of the default behavior described in
+> the last two paragraphs. If the named output is a directory that exists, then
+> any resulting executables will be written to that directory.
+
+In our case, this output directory will be the `bin` directory in a layer
+managed by the buildpack. This means that the compiled executables will
+ultimately end up on the `$PATH` as explained in the [Layer
+Paths](https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-paths)
+section of the Buildpack Spec.
+
+### Build Mode
+Additionally, we are specifying that it should compile using the
+"position-independent executable" or `pie` [build
+mode](https://golang.org/cmd/go/#hdr-Build_modes).
+
+Position-independent executables can be executed by the kernel with random
+internal memory locations for the program code.  This randomization increases
+the difficulty of executing memory overflow exploits against the running
+program. As there are no guarantees about the location of any function in
+memory, modifications to that code become considerably more difficult.
+
+The tradeoff chosen is to produce a more secure executable at the expense of a
+slightly larger filesystem/memory footprint and mild performance loss.
+
+### Targets
+The `go build` tool can compile multiple programs at the same time. We should
+leverage this feature to allow application developers to build images that
+contain multiple compiled executables.
+
+As explained in the Go documentation for [package lists and
+patterns](https://golang.org/cmd/go/#hdr-Package_lists_and_patterns), a list of
+packages is usually a list of import paths. However, for our case, we should
+only be compiling code that is local to the filesystem. The documentation explains that,
+
+> An import path that is a rooted path or that begins with a . or .. element is
+> interpreted as a file system path and denotes the package in that directory.
+
+The buildpack will support specifying multiple targets through the
+`buildpack.yml` file in a form like the following:
+
+```yaml
+---
+go:
+  targets:
+  - ./some-target
+  - ./other-target
+````
+
+Targets must be a list of paths relative to the root directory of the source
+code. The buildpack will ensure these paths are prefixed with a `./` so that
+the `go build` tool will identify them as paths local to the filesystem.
+
+### Vendoring Support
+It is expected that other buildpacks in the Go language family will provide
+external packages through a vendoring mechanism. The expectation in all of
+these cases is that the build command use the vendored code preferentially over
+downloading dependencies directly.
+
+For cases where a `vendor` directory is provided at the root of the target, the
+`go build` tool will search that directory for imported packages to compile as
+outlined in the Go documentation on [vendor
+directories](https://golang.org/cmd/go/#hdr-Vendor_Directories).
+
+For code that also uses Go modules, the `go build` command will be appended
+with the `-mod vendor` argument so that packages will be "loaded from the
+vendor directory instead of accessing the network" as defined in the Go
+documentation for [Modules and
+vendoring](https://golang.org/cmd/go/#hdr-Modules_and_vendoring). In that
+documentation, it further outlines that this behavior is the default for Go
+1.14 and higher, meaning that it does not need to be explicitly included in the
+`go build` command when using those versions. As the buildpack may currently
+support versions of Golang older than 1.14, we will continue to include the
+argument explicitly.
+
+### GOCACHE
+
+As described in the Go documentation for [build and test
+caching](https://golang.org/cmd/go/#hdr-Build_and_test_caching), the `go build`
+command will cache build outputs for reuse on subsequent invocations.  As most
+programs change incrementally, reusing outputs from this cache can provide a
+considerable compilation speed boost when rebuilding an application.
+
+To support this compilation speed boost, the buildpack will allocate a layer
+marked as `cache = true` in the Layer Content Metadata file so that the layer
+will be persisted to subsequent builds and set the `$GOCACHE` environment
+variable to that layer path during the execution of the `go build` tool.
+
+## Motivation
+
+The Go Build buildpack has a number of usecases that need support in a
+comprehensive compilation process. The `go build` command outlined above meets
+the needs of these cases, including:
+
+* compiling the source into an executable that is addressable on the `$PATH`
+* providing a more secure compiled artifact
+* compiling multiple programs in a single build invocation
+* vendoring dependencies alongside source code
+* providing a performant compilation process using caching

--- a/text/go/go-build/0002-build-flags.md
+++ b/text/go/go-build/0002-build-flags.md
@@ -1,0 +1,106 @@
+# Build Flags
+
+## Proposal
+
+The Go
+[documentation](https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies)
+of the `go build` command outlines a number of "build flags" that command users
+might set. Out of that list, the current implementation of the buildpack sets
+the `-buildmode` and `-mod` flags to default values. Application developers
+should be able to override these values and have the ability to set new values that
+are not part of the defaults.
+
+### Existing support
+The
+[go-mod](https://github.com/paketo-buildpacks/go-mod#buildpackyml-configuration)
+and [dep](https://github.com/paketo-buildpacks/dep/#buildpackyml-configuration)
+buildpacks already have configurable settings for including `-ldflags`. An
+example of that functionality can be seen below.
+
+```yaml
+---
+go:
+  ldflags:
+    main.version: v1.2.3
+    main.sha: 7a82056
+```
+
+### Proposed `buildpack.yml` format
+In order to accomodate the option to set a number of flags without needing to
+implement a separate field in the `buildpack.yml` for each of those flags, we
+propose that the `buildpack.yml` API be widened to accept a generic list of
+"build flags". In this form, the above example would look like the following:
+
+```yaml
+---
+go:
+  build:
+    flags:
+    - -ldflags='-X main.version=v1.2.3 -X main.sha=7a82056'
+```
+
+The more generic API allows us to support all of the build flags provided by
+the `go build` command without needing to widen the API contract any further.
+For example, to include build tagging and race detection during `go build`,
+application developers could specify something like the following:
+
+```yaml
+---
+go:
+  build:
+    flags:
+    - -ldflags='-X main.version=v1.2.3 -X main.sha=7a82056'
+    - -tags=paketo,production
+    - -race
+```
+
+### Breaking change
+Since the `buildpack.yml` API would change from its existing form, this is
+considered to be a breaking change and would impact buildpack users that are
+using this feature. The existing functionality would still be implemented, but
+through a more generic API.
+
+### Overriding defaults
+In addition to setting new flags, this API change will allow buildpack users to
+override those default values. For example, when a buildpack user includes
+`-buildmode=exe` in their list of build flags, it will override the default
+setting of `-buildmode=pie` for the invocation of the `go build` compilation
+process.
+
+Allowing buildpack users to override these default values is a useful feature,
+but we will need to make sure that those users understand the ramifications of
+their choice. This can simply be documentation that describes how the buildpack
+functions.
+
+## Motivation
+
+Changing the API for setting build flags will enable more configuration for
+buildpack users while simplifying the work required for buildpack developers.
+
+There are already existing users of the current LDFlags feature as well as
+[open issues](https://github.com/paketo-buildpacks/go-mod/issues/14) requesting
+that we support a larger number of flags.
+
+## Addendum: preview of future build plan configuration
+
+At a future date, this buildpack will implement the [Build Plan
+RFC](https://github.com/paketo-buildpacks/rfcs/blob/master/accepted/0003-replace-buildpack-yml.md)
+and remove support for `buildpack.yml`. In that case, the configuration above
+would change to look something like this:
+
+```toml
+[[requires]]
+name = "go-targets"
+
+[requires.metadata]
+  flags = [
+    "-ldflags='-X main.version=v1.2.3 -X main.sha=7a82056'",
+    "-tags=paketo,production",
+    "-race"
+  ]
+```
+
+At that point, the buildpack would "provide" `go-targets` as part of its build
+plan so that other buildpacks, or buildpack users could require it. Other than
+this new provision, the remainder of the configuration is a rather direct
+translation from YAML to TOML.

--- a/text/go/go-build/0003-buildpack-yml-to-env-var.md
+++ b/text/go/go-build/0003-buildpack-yml-to-env-var.md
@@ -1,0 +1,90 @@
+# Buildpack.yml to Environment Variables
+
+## Proposal
+
+Migrate to using environment variables to do all buildpack configuration and
+get rid of `buildpack.yml`.
+
+## Motivation
+
+There are several reasons for making this switch.
+1. There is already an existing RFC that proposes moving away from
+   `buildpack.yml` as a configuration tool.
+1. Environment variables appears to be the standard for configuration in other
+   buildpack ecosystems such as Google Buildpacks and Heroku as well as the
+   Paketo Java buildpacks. Making this change will align the buildpack with the
+   rest of the buildpack ecosystem.
+1. There is native support to pass environment variables to the buildpack
+   either on a per run basis or by configuration that can be checked into
+   source control, in the form of `project.toml`.
+
+## Implementation
+
+The proposed environment variables for Go Build are as follow:
+
+#### BP_GO_BUILD_FLAGS
+
+```shell
+$BP_GO_BUILD_FLAGS='-buildmode=default -tags=paketo -ldflags="-X main.variable=some-value"'
+```
+
+Note: This will be parsed using this [shellwords
+library](https://github.com/mattn/go-shellwords). This is being done because
+GOFLAGS does not support flags that have spaces in them.
+
+This will replace the following structure in `buildpack.yml`:
+
+```yaml
+go:
+  build:
+    flags:
+    - -buildmode=default
+    - -tags=paketo
+    - -ldflags="-X main.variable=some-value"
+```
+
+#### BP_GO_BUILD_IMPORT_PATH
+
+```shell
+$BP_GO_BUILD_IMPORT_PATH=example.com/some-app
+```
+
+This will replace the following structure in `buildpack.yml`:
+
+```yaml
+go:
+  build:
+    import-path: example.com/some-app
+```
+
+#### BP_GO_TARGETS
+
+```shell
+$BP_GO_TARGETS=./cmd/web-server:./cmd/debug-server
+```
+
+This will replace the following structure in `buildpack.yml`:
+
+```yaml
+go:
+  targets:
+  - ./cmd/web-server
+  - ./cmd/debug-server
+```
+
+### Deprecation Strategy
+In order to facilitate a smooth transition from `buildpack.yml`, the buildpack
+will support both configuration options with environment variables taking
+priority or `buildpack.yml` until the 1.0 release of the buildpack. The
+buildpack will detect whether or not the application has a `buildpack.yml` and
+print a warning message which will include links to documentation on how to
+upgrade and how to run builds with environment variable configuration. After
+1.0, having a `buildpack.yml` will cause a detection failure and with a link to
+the same documentation. This behavior will only last until the next minor
+release of the buildpack after which point there will no longer be and error
+but `buildpack.yml` will not be supported.
+
+## Source Material
+* [Google buildpack configuration](https://github.com/GoogleCloudPlatform/buildpacks#language-idiomatic-configuration-options)
+* [Paketo Java configuration](https://paketo.io/docs/buildpacks/language-family-buildpacks/java)
+* [Heroku configuration](https://github.com/heroku/java-buildpack#customizing)

--- a/text/go/go-build/0004-bp-go-build-ldflags.md
+++ b/text/go/go-build/0004-bp-go-build-ldflags.md
@@ -1,0 +1,75 @@
+# BP_GO_BUILD_LDFLAGS
+
+## Proposal
+
+Add an environment variable `BP_GO_BUILD_LDFLAGS` which would allow users to
+set the value of `-ldflags` for their `go build` command.
+
+## Motivation
+
+The `-ldflags` flag can have complicated values with multiple sets of internal
+quotation marks, an example of this complication can be seen in [this
+issue](https://github.com/paketo-buildpacks/go-build/issues/129). The goal of
+this environment variable is to remove one quotation level hopefully making it
+easier to express the `-ldflags` value with little to no escaping.
+
+## Implementation
+
+If `BP_GO_BUILD_LDFLAGS` is set then `-ldflags` plus the value of the
+environment variable will be added to the `go build` command.
+
+The following is an example of a cumbersome `BP_GO_BUILD_FLAGS` caused by
+`-ldflags`:
+
+`BP_GO_BUILD_FLAGS="-ldflags=\"-extldflags '-f no-PIC -static'\" -tags=osusergo,netgo,embedfs"`
+
+If the same flag set were to be written using the proposed
+`BP_GO_BUILD_LDFLAGS` it would look like this:
+
+`BP_GO_BUILD_LDFLAGS="-extldflags '-f no-PIC -static'" BP_GO_BUILD_FLAGS="-tags=osusergo,netgo,embedfs"`
+
+### Examples of Flag Merging
+
+1.
+```
+Given BP_GO_BUILD_LDFLAGS="-extldflags '-f no-PIC -static'"
+Given BP_GO_BUILD_FLAGS is unset
+
+The resulting flags would be:
+-ldflags="-extldflags '-f no-PIC -static'" -buildmode pie . # the buildmode and target are defaults added by the buildpack
+```
+Summary: If no other flags are set by the user the `BP_GO_BUILD_LDFLAGS` will
+be treated as a flag set on its own and be included as part of the build
+command.
+
+2.
+```
+Given BP_GO_BUILD_LDFLAGS="-extldflags '-f no-PIC -static'"
+Given BP_GO_BUILD_FLAGS="-tags=osusergo,netgo,embedfs"
+
+The resulting flags would be:
+-ldflags="-extldflags '-f no-PIC -static'" -tags=osusergo,netgo,embedfs -buildmode pie .
+```
+Summary: If `BP_GO_BUILD_LDFLAGS` and `BP_GO_BUILD_FLAGS` is set and
+`BP_GO_BUILD_FLAGS` does not include `-ldflags` then the `BP_GO_BUILD_LDFLAGS`
+will set `-ldflags` in the existing flag set.
+
+3.
+```
+Given BP_GO_BUILD_LDFLAGS="-extldflags '-f no-PIC -static'"
+Given BP_GO_BUILD_FLAGS="-ldflags='some-ldflags' -tags=osusergo,netgo,embedfs"
+
+The resulting flags would be:
+-ldflags="-extldflags '-f no-PIC -static'" -tags=osusergo,netgo,embedfs -buildmode pie .
+```
+Summary: If `BP_GO_BUILD_LDFLAGS` and `BP_GO_BUILD_FLAGS` is set and
+`BP_GO_BUILD_FLAGS` does include `-ldflags` then the `BP_GO_BUILD_LDFLAGS` will
+overwrite `-ldflags` in the existing flag set.
+
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+* Is this necessary? Should we just document the escaping better? Should we do
+  both?
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/go/go-dist/0001-buildpack-yml-to-env-var.md
+++ b/text/go/go-dist/0001-buildpack-yml-to-env-var.md
@@ -1,0 +1,48 @@
+# Buildpack.yml to Environment Variables
+
+## Proposal
+
+Migrate to using environment variables to do all buildpack configuration and
+get rid of `buildpack.yml`.
+
+## Motivation
+
+There are several reasons for making this switch.
+1. There is already an [existing RFC](https://github.com/paketo-buildpacks/rfcs/blob/b885abe5fe0b8f64def4a79f0952b7050f3bee6f/accepted/0003-replace-buildpack-yml.md) that proposes moving away from `buildpack.yml` as a configuration tool.
+1. Environment variables appears to be the standard for configuration in other
+   buildpack ecosystems such as Google Buildpacks and Heroku as well as the
+   Paketo Java buildpacks. Making this change will align the buildpack with the
+   rest of the buildpack ecosystem.
+1. There is native supportto pass environment variables to the buildpack
+   either on a per run basis or by configuration that can be checked into
+   source control, in the form of `project.toml`.
+
+## Implementation
+The proposed environment variables for Go Dist are as follow:
+
+#### BP_GO_VERSION
+```shell
+$BP_GO_VERSION="1.14.1"
+```
+This will replace the following structure in `buildpack.yml`:
+```yaml
+go:
+  version: 1.14.1
+```
+
+### Deprecation Strategy
+In order to facilitate a smooth transition from `buildpack.yml`, the buildpack
+should will support both configuration options with environment variables
+taking priority or `buildpack.yml` until the 1.0 release of the buildpack. The
+buildpack will detect whether or not the application has a `buildpack.yml` and
+print a warning message which will include links to documentation on how to
+upgrade and how to run builds with environment variable configuration. After
+1.0, having a `buildpack.yml` will cause a detection failure and with a link to
+the same documentation. This behavior will only last until the next minor
+release of the buildpack after which point there will no longer be and error
+but `buildpack.yml` will not be supported.
+
+## Source Material
+* [Google buildpack configuration](https://github.com/GoogleCloudPlatform/buildpacks#language-idiomatic-configuration-options)
+* [Paketo Java configuration](https://paketo.io/docs/buildpacks/language-family-buildpacks/java)
+* [Heroku configuration](https://github.com/heroku/java-buildpack#customizing)

--- a/text/go/go-mod-vendor/0001-vendor-rearchitecture.md
+++ b/text/go/go-mod-vendor/0001-vendor-rearchitecture.md
@@ -1,0 +1,65 @@
+# Go Mod Vendor Rearchitecture
+
+## Proposal
+
+The main functionality provided by the `go-mod-vendor` buildpack will be to
+provide vendored dependencies using the `go mod vendor` command. More
+information about go modules can be found [here](https://golang.org/ref/mod).
+
+`go mod vendor` first looks for the `go.mod` file in the app root directory,
+which would be there as a result of running `go mod init` before the buildpack
+is run. This would be the app developer's responsibility if they want
+to use go modules.
+
+The `go.mod` file lives at the root of the app directory and  contains the app
+dependencies, and gets updated by various go commands such as `go get`, `go
+mod tidy` or in this case `go mod vendor`.
+
+The [official documentation](https://golang.org/ref/mod#tmp_25) explains how go
+modules deal with vendoring:
+
+> The `go mod vendor` command constructs a directory named `vendor` in the main
+> module's root directory that contains copies of all packages needed to
+> support builds and tests of packages in the main module.
+
+> Once vendoring is enabled, packages are loaded from the `vendor` directory
+> instead of accessing the network or the module cache.
+
+## Integration
+
+The proposed buildpack requires `go` and provides none.
+
+The former `go-mod` buildpack used to provide `go-mod`.
+
+## Renaming
+
+The buildpack will be renamed to `go-mod-vendor` from `go-mod`. This will more
+clearly illustrate the specific function of the buildpack.
+
+The original `go-mod` buildpack contains logic that deals with binary building.
+Binary building logic will be removed from this buildpack and instead becomes a
+responsibility of the [`go-build`](https://github.com/paketo-buildpacks/go-build) buildpack.
+
+## Implementation
+
+Detection will pass if a `go.mod` file is present in the app's source code.
+
+On detection, the buildpack will perform the following steps in the Build
+phase:
+
+- Retrieve or create a `mod-cache` layer, which will be a `cache` layer.
+- Set the `GOPATH` to point at the `mod-cache` layer.
+- Run `go mod vendor`.
+
+## Motivation
+
+A big effort of the Paketo project is to move towards buildpacks that are
+responsible for a single function making the whole buildpack family structure
+more flexible, lightweight, and easier to maintain. With the proposed changes,
+the sole responsibility of this buildpack becomes managing application
+dependencies with go modules. As mentioned, the binary building logic gets
+offloaded to the `go-build` buildpack.
+
+## Source Material (Optional)
+
+[Golang Documentation on Vendoring](https://golang.org/ref/mod#tmp_25)


### PR DESCRIPTION
## Summary
Moves the rfcs from all Go repos into the text/go subdirectory as a part of #67

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
