### PR TITLE
Adds all Builder RFCs under text/builder subdirectory

### DIFF
--- a/text/builders/0000-template.md
+++ b/text/builders/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you purposing to the overall language family?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/builders/0001-buildpack-order.md
+++ b/text/builders/0001-buildpack-order.md
@@ -1,0 +1,40 @@
+# Proposed Buildpack Ordering in a Builder
+
+## Summary
+
+`pack inspect-builder gcr.io/paketo-buildpack/builder` should display a valid `Detection Order`.
+
+## Motivation
+
+After a change to the builder detection order it became impossible for `php` apps to detect, because `nginx` and `httpd` were before `php` in the detect order. 
+The `httpd.conf` or `nginx.conf` included in `php` apps will cause the `nginx` or `http` buildpacks to detect `true` before `php` ever gets to run `detect`,
+making it impossible to access the `php` buildpack.
+
+
+## Detailed Explanation
+
+We propose the following order based on the historical needs of app developers:
+
+- paketo-buildpacks/staticfile
+- paketo-community/ruby
+- paketo-buildpacks/dotnet-core
+- paketo-buildpacks/nodejs
+- paketo-buildpacks/go
+- paketo-community/python
+- paketo-buildpacks/php
+- paketo-buildpacks/nginx
+- paketo-buildpacks/httpd
+- paketo-buildpacks/java
+- paketo-buildpacks/procfile
+
+Any new buidpack will need careful consideration before deciding its place in the order.
+
+## Rationale and Alternatives
+
+An alternative solution can be found [here](https://github.com/paketo-buildpacks/builder/pull/22), in which we propose an algorithm to order buildpacks.
+
+This was rejected because, based on experience in cloud foundry, we found that a certain ordering makes the most sense for the most developers.
+
+For example, dotnet-core apps often contain `package.json` files, so `dotnet-core` must come before `nodejs`.
+
+Also, `staticfile` must come first because it can not infer detection from the source code, but must rely on `buildpack.yml` property.

--- a/text/builders/0002-buildpack-toml-versioning.md
+++ b/text/builders/0002-buildpack-toml-versioning.md
@@ -1,0 +1,71 @@
+# Checking In and Versioning Builder.toml Files
+
+## Proposal
+
+We should check in a `builder.toml` file for each version of the available
+builders. When the version of the builder gets released, we should publish a
+release and tag the repo with the correct version. There exists three different
+builders that are released separately, `full`, `base`, and `tiny`. Each builder
+should have its own repository.
+
+## Motivation
+
+Paketo users frequently ask to be able to see the `builder.toml` files used to
+create any of the Paketo Builders so that they could create custom builders
+easily. Right now builders are created in a concourse task that creates a
+temporary `builder.toml` and uses it in pack create-builder. The `builder.toml`
+file isn't saved anywhere and is lost after the task ends.
+
+We should always strive for strict versioning and reproducibility, and right
+now we have neither. It's very difficult to tell what version of what buildpack
+are in each builder, and this will make that very clear. All you would have to
+do is look at the repo at the right tag. Also, if you wanted to rebuild the
+builder, you could simply check the repo out the the correct tag.
+
+## Implementation (Optional)
+
+The proposed solution for updating the `builder.toml` is the following:
+* On some chron schedule, run a Github Action to grab the latest tag of each
+  buildpack that is a part of the builder
+  * Also grab the latest version of the lifecycle and builder image.
+* Create a temporary `builder.toml` file with those versions.
+* Check if there is a diff between the new temporary `builder.toml` and the one
+  that is already checked into the repo.
+  * If there is no diff do nothing.
+  * If there is a diff,  submit a PR with the new `builder.toml` to update it.
+* On each PR, run the smoke-tests.
+* Automatically merge the PR on passing tests.
+
+In order to publish:
+* Cut a release with a new version whenever the maintainer wants.
+  * Because the current line of builder are at `0.0.x`, we should start with
+    `0.1.0`.
+* Initally push a a temp gcr path (gcr.io/paketo-buildpacks/builder-tmp:full).
+* Start publish to all our official paths when ready.
+
+The chron schedule is the best way to keep the `builder.toml` up to date in a
+community friendly way because it is transparent and requires no work of the
+buildpack maintainers.
+
+## Alternative Implementations
+
+1. Use a Concourse pipeline to check for new buildpack versions and send
+   dispatches to the builder repos to create PRs.
+
+   This is less than ideal because it forces other users to have to update the
+   Concourse pipelines when they have new buildpacks. Using different systems
+   such as Concourse and Github Actions across different repos also adds
+   technical debt.
+
+2. Use Github Actions to send a dispatch to the builder from each buildpack
+   that feeds into the builder to notify it to create PRs.
+
+   This is less than ideal because every repo that feeds into a builder would
+   need to implement a Github Actions workflow that would be able to send a
+   dispatch to the builder repos. We do not want to put that burden onto the
+   maintainers of buildpacks.
+
+## Source Material (Optional)
+
+https://github.com/paketo-buildpacks/builder/issues/27
+https://github.com/paketo-buildpacks/builder/issues/28

--- a/text/builders/0003-automate-builder-release.md
+++ b/text/builders/0003-automate-builder-release.md
@@ -1,0 +1,69 @@
+# Automated Builder Releases
+
+## Summary
+
+This RFC proposes that the builder repos should automatically cut new releases
+(and publish the corresponding builders) whenever the `builder.toml` on the
+`main` branch changes.
+
+## Motivation
+
+Many Paketo users build app images using builders without specifying buildpacks
+separately. In order for these users to consistently build with the latest
+versions of Paketo buildpacks, builder versions must be released promptly after
+new buildpack versions are available. The current manual builder release
+process is a bottleneck.
+
+## Detailed Explanation
+
+The proposed approach is to cut releases of builders when there are commits to
+the `main` branch that change the `builder.toml`. The existing builder
+automation specified in [RFC 0002](https://github.com/paketo-buildpacks/builder/blob/main/rfcs/0002-buildpack-toml-versioning.md)
+handles updating of the `builder.toml` upon the release of new buildpack
+versions. With the proposed change, a builder will be
+automatically released when new buildpacks (or buildpack versions) are added to
+the builder. Checking whether the `builder.toml` has changed before cutting a
+release also avoids the case where a builder is released simply because of a
+cosmetic change to its repo (e.g. change to the README).
+
+## Rationale and Alternatives
+
+### Alternative 1: Do nothing
+Without this change, releases of builders will have to be cut manually. This
+has the benefit of allowing maintainers to be more judicious about when to
+release builders. The drawback is that builder release relies on manual work
+and can easily be forgotten. It also requires Builders maintainers to have
+context on the buildpacks in builders in order to understand when it makes
+sense to cut a release.
+
+### Alternative 2: Cut a release on push to `main`
+
+We can further automate the repo by cutting a release on any change to the
+`main` branch. This would be very simple to implement (basically a one-line
+change from the current automation). However, it could result in builders with
+different version numbers being functionally identical. This is perhaps
+confusing to users.
+
+## Implementation
+
+The RFC requires two changes to the current `create-draft-release.yml` workflow:
+1. Add a check to see whether the `builder.toml` differs from the latest release.
+1. Publish a non-draft release if tests pass and the `builder.toml` has changed.
+
+## Prior Art
+
+[RFC 0002](https://github.com/paketo-buildpacks/builder/blob/main/rfcs/0002-buildpack-toml-versioning.md)
+indicates that builders should be released "with a new version whenever the
+maintainer wants."
+
+Currently, Paketo implementation and language-family buildpacks are released manually by subteam maintainers.
+
+Previously, builders were released via [a concourse
+pipeline](https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/cnb-builder)
+that watched for changes to CNBs, build images, and lifecycle versions.
+
+## Unresolved Questions and Bikeshedding
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/text/builders/0004-base-builder-is-latest.md
+++ b/text/builders/0004-base-builder-is-latest.md
@@ -1,0 +1,21 @@
+# Switch `latest` to Base Builder
+
+## Summary
+
+`docker pull paketobuildpacks/builder` should pull the Base Builder.
+
+## Motivation
+
+The Base stack is the best choice for most applications. As such, the `latest` tag for stacks (`paketobuildpacks/build` and `paketobuildpacks/run`) already corresponds to the base stack.
+
+Changing the `latest` tag on the Builder to Base would bring it into sync with the stacks.
+
+## Detailed Explanation
+
+Currently, `paketobuildpacks/builder:latest` points to the latest Full builder. This should change to point to the latest Base builder.
+
+## Rationale and Alternatives
+
+We could switch the `latest` tag in the stacks to point to Full to match the Builders.
+
+This was rejected because we think the Base stack is the best option for most applications.

--- a/text/builders/0005-publish-full-builder-to-full-cf-tag.md
+++ b/text/builders/0005-publish-full-builder-to-full-cf-tag.md
@@ -1,0 +1,19 @@
+# Publish Full Builder to `full-cf` Tag
+
+## Summary
+
+`docker pull paketobuildpacks/builder:full-cf` should pull the Full Builder.
+
+## Motivation
+
+The Full builder was created to replace the Full-CF builder. This would allow us to stop shipping the Full-CF builder.
+
+## Detailed Explanation
+
+Currently, `paketobuildpacks/builder:full-cf` points to the latest Full-CF builder. This should change to point to the latest Full builder.
+
+## Rationale and Alternatives
+
+We could send out a deprecation notice to formally deprecate the Full-CF builder and tag.
+
+We would prefer not to do this yet as it will break users who have automation relying on the `full-cf` tag. It would also require us to continue shipping the Full-CF builder during the deprecation period, which we would prefer not to do.

--- a/text/builders/0006-add-procfile.md
+++ b/text/builders/0006-add-procfile.md
@@ -1,0 +1,22 @@
+# Stand-alone Procfile buildpack in the Tiny builder
+
+## Proposal
+
+The Procfile buildpack should be added as a stand-alone group to the Tiny
+builder's group orderings.
+
+## Motivation
+
+Adding the Procfile buildpack as a stand-alone order at the end of the group
+ordering list would provide users that want to run pre-built binaries on the
+smallest base image available a supported path to do so.
+
+## Source Material
+
+* The Procfile buildpack is alread a stand-alone buildpack in both the
+  [Base](https://github.com/paketo-buildpacks/base-builder/blob/77f77454f74f6eb1d71c9b2d38eb9194350f66da/builder.toml#L80-L84)
+  and the
+  [Full](https://github.com/paketo-buildpacks/full-builder/blob/8069fea85dab14880f1dc54fcba552bb9fce3e70/builder.toml#L100-L104)
+  builders.
+* The Procfile buildpack [supports the Tiny
+  stack](https://github.com/paketo-buildpacks/procfile/blob/a36fb09721cd8fa05215333379e406e20391612f/buildpack.toml#L26-L27).


### PR DESCRIPTION
## Summary
Moves the rfcs from the Builder repos into the text/builder subdirectory as a part of #67

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
