### PR TITLE
Marks RFC0042: Adjust Builder Order as Implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 * [0039: Semantic Versioning in Tags for Buildpacks](./text/0039-semantic-version-tags.md)
 * [0040: Auto-generate Reference Documentation](./text/0040-auto-reference-docs.md)
 * [0041: Use Direct Processes and exec.d](./text/0041-direct.md)
-* [0042: Adjust Builder Order](./text/0042-adjust-builder-order.md)
 * [0043: Expanding the Criteria for Reproducible Builds](./text/0043-reproducible-builds.md)
 * [0044: Provide Global Mechanism to Disable SBOM Generation](./text/0044-disable-sbom.md)
 
@@ -47,6 +46,7 @@
 * [0034: Update Hash Field in Bill of Materials](./text/0034-hash-field-bom.md)
 * [0035: Python Paketo Buildpack Promotion](./text/0035-python-promotion.md)
 * [0036: Explorations Repository](./text/0036-explorations.md)
+* [0042: Adjust Builder Order](./text/0042-adjust-builder-order.md)
 
 ## Superseded RFCs
 


### PR DESCRIPTION
Looks like this was done in each of the builders supporting Node.js.

* https://github.com/paketo-buildpacks/full-builder/pull/535
* https://github.com/paketo-buildpacks/base-builder/pull/381

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
