### PR TITLE
[PHP] Builtin Server should require composer-packages

### DIFF
--- a/text/php/0001-restructure.md
+++ b/text/php/0001-restructure.md
@@ -87,7 +87,8 @@ buildpacks[<sup>2</sup>](#note-2):
   server](https://www.php.net/manual/en/features.commandline.webserver.php) to
   serve PHP applications.
   * provides: none
-  * requires: `php` at launch
+  * requires: `php` at launch and `composer-packages` optionally at launch
+    (when composer.json is present) 
 
   This buildpack sets a start command (type `web`) to start the built-in web
   server. This is the default web server.
@@ -291,3 +292,4 @@ connect to a central data store.
 
 ## Edits
 EDIT 04/05/2022: Buildpack `composer-install` now provides `composer-packages`
+EDIT 04/18/2022: PHP Builtin Server Buildpack optionally requires `composer-packages`


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Changes made in #170 left out the fact that the PHP Builtin Server buildpack should require `composer-packages` (same as the PHP Start Buildpack).

This adds it as an optional requirement in the RFC.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
