### PR TITLE
Edit PHP 0001: Remove PHP FPM from built-in server group

### DIFF
--- a/text/php/0001-restructure.md
+++ b/text/php/0001-restructure.md
@@ -216,7 +216,7 @@ This would result in the following order groupings in the PHP language family me
     version = ""
     optional = true
 
-[[order]] # Built-in web server (web), FPM (php-fpm) & Script (Procfile)
+[[order]] # Built-in web server (web) & Script (Procfile)
 
   [[order.group]]
     id = "paketo-buildpacks/php-dist"
@@ -231,10 +231,6 @@ This would result in the following order groupings in the PHP language family me
     id = "paketo-buildpacks/composer-install"
     version = ""
     optional = true
-
-  [[order.group]]
-    id = "paketo-buildpacks/php-fpm"
-    version = ""
 
   [[order.group]]
     id = "paketo-buildpacks/php-builtin-server"
@@ -293,3 +289,4 @@ connect to a central data store.
 ## Edits
 EDIT 04/05/2022: Buildpack `composer-install` now provides `composer-packages`
 EDIT 04/18/2022: PHP Builtin Server Buildpack optionally requires `composer-packages`
+EDIT 04/24/2022: Remove FPM from the PHP Builtin Server order group


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Remove typo in which the FPM buildpack was added to the built-in server order group erroneously.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
