### PR TITLE
[Utilities] Add Live Reload Library

### DIFF
--- a/text/utilities/0006-add-live-reload-library.md
+++ b/text/utilities/0006-add-live-reload-library.md
@@ -36,7 +36,7 @@ in this case having a generic interface ("live reload") implies that eventually 
 
 ## Implementation
 
-Create a new repository to host the library: `paketo-buildpacks/libreload`.
+Create a new repository to host the library: `paketo-buildpacks/libreload-packit`.
 The root package `reload` will contain an interface that looks something like this:
 
 ```go


### PR DESCRIPTION
[Utilities] Add Live Reload Library

This has the impact of standardizing and reducing boilerplate for buildpack authors to implement live reload, typically using Watchexec. For further context, see paketo-buildpacks/packit#343.

[readable](https://github.com/joshuatcasey/rfcs/blob/jtc/utilities-add-live-reload-library/text/utilities/0006-add-live-reload-library.md)