### PR TITLE
Propose to add OpenTelemetry support for Java

### DIFF
--- a/text/java/0012-opentelemetry.md
+++ b/text/java/0012-opentelemetry.md
@@ -1,0 +1,44 @@
+# OpenTelemetry Support
+
+## Summary
+
+The [Paketo Java Buildpack](https://github.com/paketo-buildpacks/java) currently supports the APM tools Google Stackdriver, Azure Application Insights, and DataDog. This RFC proposes we add support for the open-source OpenTelemetry tool as well.
+
+## Motivation
+
+OpenTelemetry has quickly became a standard for instrumenting, collecting, and exporting telemetry data. It's adopted and supported by industry leaders in the observability space. For Java applications, an OpenTelemetry Java Agent is available for instrumenting the code and exporting traces, metrics, and logs.
+
+## Detailed Explanation
+
+This RFC proposes the following changes:
+
+- Create a new buildpack, `paketo-buildpacks/opentelemetry`.
+- The buildpack will install the OpenTelemetry Agent, which includes everything needed to instrument and export telemetry data.
+- The buildpack will adjust the JVM arguments to enable the OpenTelemetry Agent.
+- Users would configure the OpenTelemetry Agent using the [standard environment variables](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/#configuring-the-agent) provided by the OpenTelemetry project itself.
+- The initial target is for this buildpack to work with the JVM. However, support for other language families is possible in the future.
+
+## Rationale and Alternatives
+
+The goal is to add easy support for using an open-source and industry-standard for handling telemetry in Java applications. Observability is a critical property of any cloud native application, and this buildpack would make it straightforward to instrument and collect telemetry from containerized workloads. Without the buildpack, it's still possible to include the agent manually, but the user experience would not be that great.
+
+## Implementation
+
+1. Create a new repo under `paketo-buildpacks/opentelemetry`
+2. Set owner as Paketo Java subteam
+3. Push a skeleton project using libcnb/libpak
+4. Implement the buildpack based on the prototype [here](https://github.com/ThomasVitale/buildpacks-opentelemetry) (Apache 2 license)
+5. Update dependencies
+6. Add standard set of CI jobs
+7. Document usage
+8. Publish initial release
+
+## Prior Art
+
+- Azure Application Insights
+- Google Stack Driver
+- Datadog
+
+## Unresolved Questions and Bikeshedding
+
+- None

--- a/text/java/0012-opentelemetry.md
+++ b/text/java/0012-opentelemetry.md
@@ -15,7 +15,9 @@ This RFC proposes the following changes:
 - Create a new buildpack, `paketo-buildpacks/opentelemetry`.
 - The buildpack will install the OpenTelemetry Agent, which includes everything needed to instrument and export telemetry data.
 - The buildpack will adjust the JVM arguments to enable the OpenTelemetry Agent.
-- Users would configure the OpenTelemetry Agent using the [standard environment variables](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/#configuring-the-agent) provided by the OpenTelemetry project itself.
+- Users would configure the OpenTelemetry Agent using one of the following methods:
+    - via the [standard environment variables](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/#configuring-the-agent provided by the OpenTelemetry project itself.
+    - via a configuration profile provided via a dedicated `opentelemetry` binding and that will be used to set the `OTEL_JAVAAGENT_CONFIGURATION_FILE` environment variable. 
 - The initial target is for this buildpack to work with the JVM. However, support for other language families is possible in the future.
 
 ## Rationale and Alternatives
@@ -32,6 +34,8 @@ The goal is to add easy support for using an open-source and industry-standard f
 6. Add standard set of CI jobs
 7. Document usage
 8. Publish initial release
+9. Submit sample application [here](https://github.com/paketo-buildpacks/samples/tree/main/java)
+10. Update the Java documentation [here](https://github.com/paketo-buildpacks/paketo-website/blob/main/content/docs/howto/java.md#connect-to-an-apm)
 
 ## Prior Art
 


### PR DESCRIPTION
## Summary
Add a Buildpacks for contributing the OpenTelemetry Java Agent to Java applications. [Readable](https://github.com/paketo-buildpacks/rfcs/blob/388b2f399f0b8cada1ab065ba16ca356ec054d04/text/java/0012-opentelemetry.md)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
