### PR TITLE
Add rfc to include libs to tiny that are needed for node

### DIFF
--- a/text/stacks/0000-node-on-tiny.md
+++ b/text/stacks/0000-node-on-tiny.md
@@ -26,18 +26,25 @@ apps/node-base                        latest     022cb9cea147   41 years ago   2
 apps/node-full                        latest     1324267830ec   41 years ago   803MB
 ```
 
+Additionally image scans would find less CVEs which would make it easier to assess.
+
+| Image | Size Run Image (MB) | Total CVEs | CVEs >= 7 |
+| --- | --- | --- | --- |
+| run-node-tiny | 19.2 |  27 | 14 |
+| paketobuildpacks/run:tiny | 17.4 | 28 | 14 |
+| paketobuildpacks/run:base | 86.7 | 58 | 40 |
+
 ## Detailed Explanation
 
 Install the [`libstdc++6`](https://packages.ubuntu.com/bionic/libstdc++6) and [`libgcc1`](https://packages.ubuntu.com/bionic/libgcc1) packages for the Ubuntu based tiny run image. It looks like this will add around 1.8 MB.
 
-```bash
-run-node-tiny                        latest     43acd28c97af   41 years ago   19.2MB
-paketobuildpacks/run:tiny            latest     fa34fc0b3d7b   41 years ago   17.4MB
-```
+The image scan results when writing this pr "only" showed one additional CVE (5.5) which would need to be assessed.
 
 ## Rationale and Alternatives
 
-1. Node is written in C++, so it needs `libstdc++6`and `libgcc1` at runtime.
+- Node is written in C++, so it needs `libstdc++6`and `libgcc1` at runtime.
+- This would also allow other apps to use the tiny stack, e.g. Rust, C++, SAP JVM
+- This might be solved with the use of `extensions` which is currently discussed
 
 ## Implementation
 
@@ -50,4 +57,4 @@ None
 ## Unresolved Questions and Bikeshedding
 
 - Is it worth to influence other users of the stack?
-- Currently the `npm start` buildpack requires a `bash`, so any Node.js application using a start script would fail.
+- Currently the `npm start` buildpack requires a `bash`, so any Node.js application using a start script would fail, but this might be changed in `npm start`

--- a/text/stacks/0000-node-on-tiny.md
+++ b/text/stacks/0000-node-on-tiny.md
@@ -1,0 +1,53 @@
+# Add to Tiny Run Image to Enable Node Apps
+
+## Summary
+
+At the moment, Node.js applications are not compatible with the tiny builder. Therefor the `nodejs` buildpack does not support the tiny stack.
+
+The tiny build image is already capable of building the Node.js application.
+
+The tiny run image is missing `libstdc++6`and `libgcc1`.
+
+## Motivation
+
+To support running Node.js applications with the tiny builder.
+
+While not all Node.js applications could be supported by that, this could be a feasible approach:
+
+- `tiny`: Run Node.js applications **without** any native extenstions
+- `base`: Run Node.js applications **without** many native extensions
+- `full`: Run Node.js applications **with** many native extensions
+
+This should be desirable as some types of Node.js application would benefit of the reduced image size.
+
+```bash
+apps/node-tiny                        latest     7546c8d45780   41 years ago   130MB
+apps/node-base                        latest     022cb9cea147   41 years ago   202MB
+apps/node-full                        latest     1324267830ec   41 years ago   803MB
+```
+
+## Detailed Explanation
+
+Install the [`libstdc++6`](https://packages.ubuntu.com/bionic/libstdc++6) and [`libgcc1`](https://packages.ubuntu.com/bionic/libgcc1) packages for the Ubuntu based tiny run image. It looks like this will add around 1.8 MB.
+
+```bash
+run-node-tiny                        latest     43acd28c97af   41 years ago   19.2MB
+paketobuildpacks/run:tiny            latest     fa34fc0b3d7b   41 years ago   17.4MB
+```
+
+## Rationale and Alternatives
+
+1. Node is written in C++, so it needs `libstdc++6`and `libgcc1` at runtime.
+
+## Implementation
+
+Install the `libstdc++6` and `libgcc1` packages for the Ubuntu based tiny run image.
+
+## Prior Art
+
+None
+
+## Unresolved Questions and Bikeshedding
+
+- Is it worth to influence other users of the stack?
+- Currently the `npm start` buildpack requires a `bash`, so any Node.js application using a start script would fail.

--- a/text/stacks/0000-node-on-tiny.md
+++ b/text/stacks/0000-node-on-tiny.md
@@ -15,7 +15,7 @@ To support running Node.js applications with the tiny builder.
 While not all Node.js applications could be supported by that, this could be a feasible approach:
 
 - `tiny`: Run Node.js applications **without** any native extenstions
-- `base`: Run Node.js applications **without** many native extensions
+- `base`: Run Node.js applications **with** some native extensions
 - `full`: Run Node.js applications **with** many native extensions
 
 This should be desirable as some types of Node.js application would benefit of the reduced image size.
@@ -26,13 +26,13 @@ apps/node-base                        latest     022cb9cea147   41 years ago   2
 apps/node-full                        latest     1324267830ec   41 years ago   803MB
 ```
 
-Additionally image scans would find less CVEs which would make it easier to assess.
+Additionally image scans would find less CVEs for the application image which would make it easier to assess. On the other side, no additional CVEs for the run images (compared to `tiny`) were found by addind these libraries.
 
-| Image | Size Run Image (MB) | Total CVEs | CVEs >= 7 |
-| --- | --- | --- | --- |
-| run-node-tiny | 19.2 |  27 | 14 |
-| paketobuildpacks/run:tiny | 17.4 | 28 | 14 |
-| paketobuildpacks/run:base | 86.7 | 58 | 40 |
+| Image | Size Run Image (MB) |
+| --- | --- |
+| run-node-tiny | 19.2 |
+| paketobuildpacks/run:tiny | 17.4 |
+| paketobuildpacks/run:base | 86.7 |
 
 ## Detailed Explanation
 

--- a/text/stacks/0000-node-on-tiny.md
+++ b/text/stacks/0000-node-on-tiny.md
@@ -57,4 +57,4 @@ None
 ## Unresolved Questions and Bikeshedding
 
 - Is it worth to influence other users of the stack?
-- Currently the `npm start` buildpack requires a `bash`, so any Node.js application using a start script would fail, but this might be changed in `npm start`
+- Currently the `npm start` buildpack requires a `bash`, so any Node.js application using a start script would fail, but this can be changed in `npm start`


### PR DESCRIPTION
[Readable](https://github.com/sap-contributions/rfcs/blob/node-tiny-stack/text/stacks/0000-node-on-tiny.md)

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
> At the moment, Node.js applications are not compatible with the tiny builder. Therefor the `nodejs` buildpack does not support the tiny stack.

>The tiny build image is already capable of building the Node.js application.

>The tiny run image is missing `libstdc++6`and `libgcc1`.

This RFC should address this.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Simple node.js app are forced to use the `base` stack with its increased size and CVE surface. Supporting them on `tiny` could be an improvement.


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
