### PR TITLE
Edit Dependency RFCs: Migrate from SHA256 field to Checksum

### DIFF
--- a/text/dependencies/rfcs/0004-dependency-management-phase-one.md
+++ b/text/dependencies/rfcs/0004-dependency-management-phase-one.md
@@ -148,11 +148,11 @@ generalized for running in automation, while being useable locally.
       {
         "name": <dependency name>,
         "version": <version>,
-        "sha256": <SHA256>,
+        "checksum": <algorithm>:<hash of dependency>,
         "uri": <URI of dependency>,
         "stacks": [{"id": <compatible stack ID> }],
         "source": <source URI>,
-        "source_sha256": <SHA256 of source dependency>,
+        "source-checksum": <algorithm>:<hash of source dependency>,
         "deprecation_date": <optional field, deprecation date>,
         "cpe": <CPE>,
         "purl": <package URL>,
@@ -191,8 +191,8 @@ Code to generate/gather all of the metadata for a dependency should be moved and
 into the retrieval code.  The code should
 do essentially the same thing that the existent code does, and support the same
 metadata fields.
-The supported metadata fields are: `source URI`, `source SHA256`, `version`,
-`URI`, `SHA256`, `ReleaseDate`, `DeprecationDate`, `stacks`, `purl`, `licenses`
+The supported metadata fields are: `source URI`, `source checksum`, `version`,
+`URI`, `checksum`, `ReleaseDate`, `DeprecationDate`, `stacks`, `purl`, `licenses`
 and `CPE`.
 
 #### Separating OS Variants and Supporting Multiple Stacks
@@ -217,12 +217,12 @@ The other entry will be for Jammy, with the `target` set to something like
 
 #### Caveat: Compiled Dependencies
 In the case that the dependencies need to be compiled or processed, the
-metadata generation code should omit the `URI` and the `SHA256` from the
+metadata generation code should omit the `URI` and the `checksum` from the
 metadata. This will be used in automation (described in detail in a subsequent
 RFC) to let the dependency management system to trigger compilation of the
 dependency. When the dependency is compiled and uploaded to a bucket, the
-bucket URI will be the URI in the metadata, and the compiled dependency SHA256
-will be the SHA256 in the metadata.
+bucket URI will be the URI in the metadata, and the compiled dependency checksum
+will be the checksum in the metadata.
 
 #### New Repository
 Eventually, commonalities in version retrieval code (and other parts of the
@@ -303,8 +303,9 @@ this behaviour lives now.
       buildpack author desires. The dependency name will be highly dependent on
       if the dependency needs to be compiled separately for different
       OS/architecture combinations.
-    * Artifact SHASUM -  A `${dependency}-<description>.tgz.sha256` file
-      containing the SHA256 of the compiled dependency.
+    * Artifact checksum -  A `${dependency}-<description>.tgz.checksum` file
+      containing the checksum of the compiled dependency in the form of
+      `<algorithm>:<hash>`.
 
 #### Compilation Action
 The compilation step will be written as a Github Action in order to facilitate
@@ -438,3 +439,7 @@ project, potentially making it hard to contribute and maintain.
 
 ## Unresolved Questions and Bikeshedding (Optional)
 - Who is going to pay for the buckets?
+
+
+## Edits
+- 09/21/2022 - Migrate from `sha256` and `source_sha256` fields to `checksum` and `source-checksum` fields in metadata.

--- a/text/dependencies/rfcs/0005-dependency-management-phase-two.md
+++ b/text/dependencies/rfcs/0005-dependency-management-phase-two.md
@@ -104,7 +104,7 @@ work as a single workflow:
    metadata entries may exist representing different OS target groups. If a
    separate dependency is needed to run on different stacks, this will be
    enumarated as separate metadata entries.
-2. For each metadata entry, if the `SHA256` and `URI` metadata fields are
+2. For each metadata entry, if the `checksum` and `uri` metadata fields are
    empty, trigger compilation. This will likely be achieved by using a Github
    Actions [`matrix
    strategy`](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy)
@@ -117,7 +117,7 @@ work as a single workflow:
    buildpack maintainer's discretion whether it needs to be tested. All
    compiled dependencies will be tested.
 6. (If compiled) Upload the dependency to the dependency bucket
-7. (If compiled) The dependency `SHA256` and the bucket `URI` are added to metadata
+7. (If compiled) The dependency `checksum` and the bucket `uri` are added to metadata
 8. An "Assemble" step will run, taking in metadata, the dependencies, and will
    update the `buildpack.toml` file with the new versions and metadata.  The
    step will pass these inputs into a stripped-down version of the `jam
@@ -163,9 +163,9 @@ would have two entries per version:
     licenses = ["MIT", "MIT-0"]
     name = "Bundler"
     purl = "pkg:generic/bundler@2.3.15?checksum=05b7a8a409982c5d336371dee433e905ff708596f332e5ef0379559b6968431d&download_url=https://rubygems.org/downloads/bundler-2.3.15.gem"
-    sha256 = "some-sha"
+    checksum = "sha256:some-sha"
     source = "https://rubygems.org/downloads/bundler-2.3.15.gem"
-    source_sha256 = "05b7a8a409982c5d336371dee433e905ff708596f332e5ef0379559b6968431d"
+    source-checksum = "sha256:05b7a8a409982c5d336371dee433e905ff708596f332e5ef0379559b6968431d"
     stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
     uri = "some-GCP-bucket-URI://bundler-2.3.15-ubuntu.tgz"
     version = "2.3.15"
@@ -176,9 +176,9 @@ would have two entries per version:
     licenses = ["MIT", "MIT-0"]
     name = "Bundler"
     purl = "pkg:generic/bundler@2.3.15?checksum=05b7a8a409982c5d336371dee433e905ff708596f332e5ef0379559b6968431d&download_url=https://rubygems.org/downloads/bundler-2.3.15.gem"
-    sha256 = "some-sha"
+    checksum = "sha256:some-sha"
     source = "https://rubygems.org/downloads/bundler-2.3.15.gem"
-    source_sha256 = "05b7a8a409982c5d336371dee433e905ff708596f332e5ef0379559b6968431d"
+    source-checksum = "sha256:05b7a8a409982c5d336371dee433e905ff708596f332e5ef0379559b6968431d"
     stacks = ["some-windows-stack"]
     uri = "some-GCP-bucket-URI://bundler-2.3.15-windows.tgz"
     version = "2.3.15"
@@ -186,7 +186,7 @@ would have two entries per version:
 
 The `buildpack.toml` will have multiple variant entries for every version, and
 there will be more variants as the buildpack supports more stacks. Variants
-differ by `URI`, `SHA256`, and `stacks`. In order to control increasing
+differ by `URI`, `checksum`, and `stacks`. In order to control increasing
 `buildpack.toml` complexity and duplication, some method to abstract duplicated
 fields might be helpful, and can be introduced in a separate RFC.
 
@@ -218,3 +218,6 @@ visibilty and would require quite a bit of overhead to set up a new system.
   failures?
 - Should we introduce a mechanism to perform the workflow for a single input
   version?
+
+## Edits
+- 09/21/2022 - Migrate from `sha256` and `source_sha256` fields to `checksum` and `source-checksum` fields in metadata.


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

With changes introduced in https://github.com/paketo-buildpacks/packit/pull/389, we should use the new `checksum` and `source-checksum` fields instead of `sha256` and `source-sha256`.

This PR makes an edit to existent dependency RFCs to leverage the checksum concept instead of `sha256`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
