### PR TITLE
Adds RFC to remove Ruby from the Jammy Full stack

### DIFF
--- a/text/stacks/0008-jammy-full-remove-ruby.md
+++ b/text/stacks/0008-jammy-full-remove-ruby.md
@@ -1,0 +1,45 @@
+# Remove Ruby from the Jammy Full Stack
+
+## Summary
+
+The Jammy Full stack should not install the `ruby` package.
+
+## Motivation
+
+The `ruby` (Ruby 3.0) package will reach the end of its support period (March
+2024) before Jammy does (April 2027). This means that for a large portion of
+the support period for the Jammy Full stack, it will contain an unsupported
+Ruby interpreter.
+
+Additionally, removing the `ruby` package will have little impact on existing
+Jammy Full stack users since they will be able to still get a Ruby interpreter
+through the `mri` buildpack or by employing a stack extension to install the
+`ruby` package.
+
+Finally, the existence of the `ruby` package in the stack is a relic of its
+ancestry having been developed from the Cloud Foundry `cflinuxfs*` line of stack
+images. In those stacks, the `ruby` package was required because some number of
+buildpacks were written in Ruby and required an interpreter on the stack to
+run. Given that Paketo does not have any buildpacks written in Ruby, the
+original rationale for including the `ruby` package is gone.
+
+## Detailed Explanation
+
+Removing the `ruby` package from both the build and run image definitions in
+the `stack.toml` file will result in an image that no longer includes that
+package.
+
+## Rationale and Alternatives
+
+## Implementation
+
+Remove the `ruby` package from the build and run package lists in the
+`stack.toml` file.
+
+## Prior Art
+
+None
+
+## Unresolved Questions and Bikeshedding
+
+None

--- a/text/stacks/README.md
+++ b/text/stacks/README.md
@@ -7,6 +7,7 @@ This directory contains RFCs that pertain to the [Stacks Subteam](https://github
 * [0004: Stacks based on Ubuntu 2022.04: Jammy Jellyfish](0004-jammy-jellyfish.md)
 * [0006: Add to Tiny Run Image to Enable Node Apps](0006-node-on-tiny.md)
 * [0007: Squash Stack Images](0007-squash-stack.md)
+* [0008: Remove Ruby from the Jammy Full Stack](0008-jammy-full-remove-ruby.md)
 
 ## Implemented RFCs
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
[Readable](https://github.com/paketo-buildpacks/rfcs/blob/full-stack-remove-ruby/text/stacks/0007-jammy-full-remove-ruby.md)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
