### PR TITLE
Require a specific java version in the buildplan

### DIFF
--- a/text/java/0000-require-specific-java-version.md
+++ b/text/java/0000-require-specific-java-version.md
@@ -32,6 +32,13 @@ Currently, `libjvm` alone is deciding what version of java dependency is provide
 
 ## Implementation
 
+If the user requests a specific version via `BP_JRE_VERSION`, that version should always be taken.
+
 ## Prior Art
 
+The same is possible for choosing the `node` version in the [node-engine buildpack](https://github.com/paketo-buildpacks/node-engine)
+
 ## Unresolved Questions and Bikeshedding
+
+* How to handle possible conflicts?
+* Is this adding too much complexity?

--- a/text/java/0000-require-specific-java-version.md
+++ b/text/java/0000-require-specific-java-version.md
@@ -1,0 +1,37 @@
+# Require a specific version of a `JDK` or `JRE` in the buidplan
+
+## Summary
+
+Currently, buildpacks can require a `jre` or `jdk` in a buildplan. But the actual version of this dependency is completely up to the buildpack providing the dependency (e.g. [bellsoft-liberica](https://github.com/paketo-buildpacks/bellsoft-liberica)).
+
+The [Buildpack Interface Specification](https://github.com/buildpacks/spec/blob/main/buildpack.md#build-plan-toml-requiresversion-key) allows to specify `requires.metadata.version`to request a specific version of the dependency.
+
+## Motivation
+
+When some `buildpack` knows more information about the required java version (e.g. as part of the `pom.xml`), it still relys on the providing buildpack to pick the right version or for the user to request it. This could ease the usage of `buildpacks` for java applications.
+
+## Detailed Explanation
+
+A buildplan would look like
+
+```toml
+[[requires]]
+name = "jdk"
+
+[requires.metadata]
+version = "17"
+```
+
+This is requesting a `jdk` in version 17.
+
+## Rationale and Alternatives
+
+Otherwise the default version would be chosen (which is 11) or the user would have to specify the version via `BP_JRE_VERSION`.
+
+Currently, `libjvm` alone is deciding what version of java dependency is provided. This feels strange because `libjvm` does not even know why the java dependency was requested in the first place.
+
+## Implementation
+
+## Prior Art
+
+## Unresolved Questions and Bikeshedding


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

[Readable](https://github.com/sap-contributions/rfcs/blob/adf972d66f6c4ab3349588d0d9552af8697fce9b/text/java/0000-require-specific-java-version.md)

When a `requires` in the buildplan requests a `jdk` or `jre`, it could also provide some metadata on which version is needed.

## Summary
<!-- A short explanation of the proposed change -->
```toml
[[requires]]
name = "jdk"

[requires.metadata]
version = "17"
```

This would not rely on the default version to be the right one or force the user to provide the needed version.

## Use Cases
<!-- An explanation of the use cases your change enables -->

As discussed here: https://github.com/paketo-buildpacks/maven/issues/217

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
