### PR TITLE
Adds new Java RFC for composite draft branches

### DIFF
--- a/text/java/0000-composite-draft-branch.md
+++ b/text/java/0000-composite-draft-branch.md
@@ -1,0 +1,39 @@
+# Create a draft branch for composite/meta buildpacks
+
+## Summary
+
+Currently component buildpack bumps are created as PRs against the main branch, e.g. see [here](https://github.com/paketo-buildpacks/java/pull/873).
+This RFC proposes changing the CI to create these dependency PRs against a new branch, e.g. `draft`.    
+
+## Motivation
+
+This will allow us to achieve the following improvements:
+
+1. Auto-merging of component buildpack PRs into this draft branch 
+2. Manual review can be performed with a single PR before merging to main
+2. Integration tests can be run on merging to main ensuring all changes in the release are covered
+
+## Detailed Explanation
+
+Currently the component dependency PRs must be manually approved and merged separately, even though their changes do not cause merge conflicts. Auto-merging these will reduce the maintainence burden involved here.
+Integration tests can configured to run on merges to the main branch, which could happen once per week before a release, or more frequently if necessary for a specific purpose.
+
+## Rationale and Alternatives
+
+1. Do not change the current CI/branch configuration - integration tests could be run via a manual step before release.
+2. Do not change the current CI/branch configuration - create new release tags as a separate initial step before a release is published. Integration tests could be run on tag creation instead, with the publish action potentially triggered from passed tests. 
+
+## Implementation
+
+For the composite/meta buildpack repositories:
+
+1. The pipeline-builder CI workflow step that updates package [dependencies](https://github.com/paketo-buildpacks/pipeline-builder/blob/main/octo/package_dependencies.go) would be changed to checkout a draft branch rather than the default of main. The PR for containing the update would then be created targeting this branch. 
+2. We would likely need a new workflow which triggers on merges to the 'draft' branch and opens/updates a PR to merge the dependency changes into main. The integration tests could be triggered here also.
+
+## Prior Art
+
+N/A
+
+## Unresolved Questions and Bikeshedding
+
+N/A

--- a/text/java/0000-composite-draft-branch.md
+++ b/text/java/0000-composite-draft-branch.md
@@ -3,7 +3,7 @@
 ## Summary
 
 Currently component buildpack bumps are created as PRs against the main branch, e.g. see [here](https://github.com/paketo-buildpacks/java/pull/873).
-This RFC proposes changing the CI to create these dependency PRs against a new branch, e.g. `draft`.    
+This RFC proposes changing the CI to create these dependency bumps as commits to a PR against a new branch, e.g. `draft`.    
 
 ## Motivation
 
@@ -32,7 +32,7 @@ For the composite/meta buildpack repositories:
 
 ## Prior Art
 
-N/A
+This is how `buildpack.toml` is updated in non-Java composite buildpacks, see [this PR](https://github.com/paketo-buildpacks/python/pull/555/files)
 
 ## Unresolved Questions and Bikeshedding
 


### PR DESCRIPTION
[Readable](https://github.com/paketo-buildpacks/rfcs/blob/composite-draft-branch/text/java/0000-composite-draft-branch.md)

## Summary
This RFC proposes a change to the pipeline-builder CI which will target the composite/meta buildpack repositories, e.g. paketo-buildpacks/java, and change the branch that component buildpack bump PRs are created against. 

## Use Cases
This will allow integration tests to be run on merges to the main branch once component buildpack bumps are in and ready for release. This should also reduce the maintenance burden as the component bumps can be auto-merged with review possible before the merge to main.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
