### PR TITLE
RFC: Selecting the next default Java Version

### DIFF
--- a/text/0000-selecting-default-java-version.md
+++ b/text/0000-selecting-default-java-version.md
@@ -22,7 +22,9 @@ The default should be changed according to a defined process rather than at some
 
 ## Implementation
 
-To fulfill this RFC, the default version should be changed to Java 17. All future versions should be bumped according to this RFC.
+To fulfill this RFC, the default version should be changed to Java 17 immediately. 
+
+Going forward, the default Java version should be bumped according to this RFC.
 
 ## Prior Art
 

--- a/text/0000-selecting-default-java-version.md
+++ b/text/0000-selecting-default-java-version.md
@@ -10,7 +10,7 @@ Currently, there is no process how the default version of Java is picked in the 
 
 ## Detailed Explanation
 
-The default should be changed according to a defined process rather than at some undefined point in time to some undefined version. To do so, the default should be changed once the latest releases LTS version of Java is at least one year old. 
+The default should be changed according to a defined process rather than at some undefined point in time to some undefined version. To do so, the default should be changed once the latest releases LTS version of Java is at least one year old. Setting this as the baseline, exceptions of faster (or slower) updates are acceptable in urgent cases.
 
 ## Rationale and Alternatives
 
@@ -22,13 +22,9 @@ The default should be changed according to a defined process rather than at some
 
 ## Implementation
 
-To fulfill this RFC, the default version should be changed to Java 17 immediately. 
+To fulfill this RFC, the default version should be changed to Java 17 immediately. Additionally, the process on how the community is notified about the update should be documented on paketo.io/docs.
 
 Going forward, the default Java version should be bumped according to this RFC.
-
-## Prior Art
-
-n/a
 
 ## Unresolved Questions and Bikeshedding
 

--- a/text/0000-selecting-default-java-version.md
+++ b/text/0000-selecting-default-java-version.md
@@ -10,7 +10,7 @@ Currently, there is no process how the default version of Java is picked in the 
 
 ## Detailed Explanation
 
-The default should be changed according to a defined process rather than at some undefined point in time to some undefined version. To do so, the default should be changed once the latest releases LTS version of Java is at least one year old. Setting this as the baseline, exceptions of faster (or slower) updates are acceptable in urgent cases.
+The default should be changed according to a defined process rather than at some undefined point in time to some undefined version. To do so, the default should be changed once the latest released LTS version of Java is at least one year old. Exceptions are permitted for a shorter change cycle when deemed sufficiently urgent by a majority vote of Java subteam contributors and maintainers.
 
 ## Rationale and Alternatives
 

--- a/text/0000-selecting-default-java-version.md
+++ b/text/0000-selecting-default-java-version.md
@@ -1,0 +1,34 @@
+# Selecting the next default Java Version for Paketo Buildpacks
+
+## Summary
+
+This RFC introduces a process to select the next default version of the Paketo Java Buildpack.
+
+## Motivation
+
+Currently, there is no process how the default version of Java is picked in the Paketo world. As of today (January 2023), the default still is Java 11 (released September 2018) although Java 17 (released September 2021) is already available.
+
+## Detailed Explanation
+
+The default should be changed according to a defined process rather than at some undefined point in time to some undefined version. To do so, the default should be changed once the latest releases LTS version of Java is at least one year old. 
+
+## Rationale and Alternatives
+
+- Do nothing, update default manually from time to time
+- Always use the latest LTS immediately
+  - Could break people immediately
+- This RFC
+  - Gives room to adapt to breaking changes
+
+## Implementation
+
+To fulfill this RFC, the default version should be changed to Java 17. All future versions should be bumped according to this RFC.
+
+## Prior Art
+
+n/a
+
+## Unresolved Questions and Bikeshedding
+
+- Define the time to wait after a new LTS was published
+- Should this be an automated process?


### PR DESCRIPTION
## Summary

This RFC proposes a general pattern/process on when to update the default Java version used in the respective buildpack. See https://github.com/paketo-buildpacks/maven/issues/217#issuecomment-1345375874 for more details.

## Use Cases

Users can expect the default version of Java to advance in a regular manner.

## Checklist

* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

CC @loewenstein @pbusko 