### PR TITLE
Add companion buildpack repos to UBI RFC

### DIFF
--- a/text/0056-ubi-based-stacks.md
+++ b/text/0056-ubi-based-stacks.md
@@ -166,6 +166,14 @@ The buildpacks team will create two new repos within the Paketo Community Organi
 * `ubi-java-extension`
 * `ubi-nodejs-extension`
 
+The buildpacks team will create two new repos within the Paketo Community Organisation for the initial two companion buildpacks.
+
+(_Extensions are unable to perform all the tasks of Buildpacks, necessitating the creation of Buildpacks to carry out
+some actions such as configuration of the runtime environment via layers. These Buildpacks can be considered as companions to their Extension namesakes._)
+
+* `ubi-java-buildpack`
+* `ubi-nodejs-buildpack`
+
 The builders-maintainers team will create the repo within the Paketo Community Organisation for the Builder image
 
 * `builder-ubi-base`


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
During authoring of the UBI builder images, the limitations of Extensions were better understood. 
Extensions are unable to write layers, and thus cannot configure the runtime environment via layers. 
To perform this kind of configuration, we can create a Buildpack to act as a companion to the Extension.

As discussed on Working Group call. This PR includes the companion Buildpack repo's into the UBI RFC.

## Use Cases
<!-- An explanation of the use cases your change enables -->
UBI-Java-Extension will install the runtime.
UBI-Java-Buildpack will apply the runtime configuration via layers. 

Nodejs will be similar.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
