### PR TITLE
Add RFC to unify log output

### DIFF
--- a/text/0000-unify-log-output.md
+++ b/text/0000-unify-log-output.md
@@ -1,0 +1,39 @@
+# Unified Log Output For All Paketo Buildpacks
+
+## Summary
+
+There are 2 different ways logging is done in the buildpacks:
+
+* buildpacks based on `packit/v2` seem to use `packit/v2/scribe`
+* buildpacks based on `libpak` seem to use `libpak/bard`  
+
+Unfortunately, this results is log output that looks different because of the use of colors and different styles `libpak/bard`. `packit/v2/scribe` is simpler and only uses plain text.
+
+## Motivation
+
+I think it would be beneficial if paketo buildpacks have a unified Look&Feel. This is excpecially true for meta buildpacks that include both "types" of buildpacks (e.g. `nodejs`).
+
+Just use [npm sample](https://github.com/paketo-buildpacks/samples/tree/main/nodejs/npm) to see the different log outputs.
+
+## Detailed Explanation
+
+All buildpacks would use the same logger.
+
+## Rationale and Alternatives
+
+
+* Keep it like it is.
+
+* Change one of the loggers to match the output of the other.
+
+## Implementation
+
+This could either be done by having all buildpacks to change to a specific logger (preferrable `libpak/bard` since the output is nicer). Or by creating a common library including logging (based on `libpak/bard`) and adapt this library with all buildpacks.
+
+This common library could then could then even contain more things both approaches (`libpack` and `packit`) have in common. 
+
+## Prior Art
+
+
+## Unresolved Questions and Bikeshedding
+


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
There are 2 different ways logging is done in the buildpacks:

* buildpacks based on `packit/v2` seem to use `packit/v2/scribe`
* buildpacks based on `libpak` seem to use `libpak/bard`  

## Use Cases

Using a meta buildpack containing buildpacks from both approaches, e.g see [npm sample](https://github.com/paketo-buildpacks/samples/tree/main/nodejs/npm) 

## Checklist
<!-- Please confirm the following -->
* [ X I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
