### PR TITLE
Propose adding ubi9 base images to paketo buildpacks

### DIFF
--- a/text/0000-add-ubi9-base-images.md
+++ b/text/0000-add-ubi9-base-images.md
@@ -1,0 +1,48 @@
+# Create UBI9 base images
+
+## Summary
+
+This RFC proposes creating a new repository that will develop, release, and maintain the UBI9 base images for use with buildpacks.
+
+## Motivation
+
+Paketo Buildpacks organization ships UBI images based on RHEL 8 operating system and currently the default OS for base images offered by Red Hat is RHEL 9. By shipping UBI9 base images from Paketo Buildpacks organization, we allow users to build their applications with buildpacks on top of UBI9 base images and in addition, users can test their applications against the UBI9 base images for easier transition until UBI8 becomes EOL.
+
+## Detailed Explanation
+
+Create a new repository named `paketo-buildpacks/ubi-9-base-images` and similar to how the (UBI8)[https://github.com/paketo-buildpacks/ubi8-base-stack] repository is structured and works, adjust it accordingly to produce the UBI9 base images.
+
+## Rationale and Alternatives
+
+- We could release the UBI9 images under the UBI8 repository, but this would confuse the users and also does not follow the naming convention we use across the Paketo Buildpacks organization.
+- We could have ubi8 and ubi9 images under one repository, but in that case, there is a risk of hitting github limitations, e.g., the number of jobs each github workflow is allowed to run concurrently, and it will also trigger the UBI8 releases in case there is a UBI9 one available.
+
+## Implementation
+
+1. Create a new repository named `paketo-buildpacks/ubi-9-base-images`
+
+1. The workflows of this repository should produce at least below container base images based on UBI9 images and also being able to extend the list in case future ubi-\*-extensions be available e.g. python, go, etc.:
+
+- `build-ubi9-base`
+- `run-ubi9-base`
+- `run-java-8-ubi9-base`
+- `run-java-11-ubi9-base`
+- `run-java-17-ubi9-base`
+- `run-java-21-ubi9-base`
+- `run-nodejs-16-ubi9-base`
+- `run-nodejs-18-ubi9-base`
+- `run-nodejs-20-ubi9-base`
+
+## Prior Art
+
+The structure and implementation of the repository that will release, maintain, and develop UBI9 base images, will follow the structure/implementation of following stacks/images repositories:
+
+- https://github.com/paketo-buildpacks/ubi8-base-stack
+- https://github.com/paketo-buildpacks/jammy-base-stack
+- https://github.com/paketo-buildpacks/jammy-full-stack
+- https://github.com/paketo-buildpacks/jammy-static-stack
+- https://github.com/paketo-buildpacks/ubuntu-noble-base-images
+
+## Unresolved Questions and Bikeshedding
+
+N/A


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds RFC for supporting Universal Base Images (UBI) based on RHEL 9

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
