### PR TITLE
Propose adding Resolute Raccoon base images

### DIFF
--- a/text/stacks/0010-resolute-raccoon.md
+++ b/text/stacks/0010-resolute-raccoon.md
@@ -27,9 +27,9 @@ offered in the Noble base images. The variants will be called `build`, `run`, `r
 `run-static` just as they are in the Noble base images. Each should be developed to offer
 roughly the same set of OS-level package support as their Noble equivalent.
 
-### Base image IDs
+### Stack IDs
 
-Base image IDs will be given to each variant of the base images as follows:
+Stack IDs will be given to each variant of the base images as follows:
 
 * Build: `io.buildpacks.base.images.resolute`
 * Run: `io.buildpacks.base.images.resolute`

--- a/text/stacks/0010-resolute-raccoon.md
+++ b/text/stacks/0010-resolute-raccoon.md
@@ -31,10 +31,10 @@ roughly the same set of OS-level package support as their Noble equivalent.
 
 Stack IDs will be given to each variant of the base images as follows:
 
-* Build: `io.buildpacks.base.images.resolute`
-* Run: `io.buildpacks.base.images.resolute`
-* Run tiny: `io.buildpacks.base.images.resolute.tiny`
-* Run static: `io.buildpacks.base.images.resolute.static`
+* Build: `io.buildpacks.stacks.resolute`
+* Run: `io.buildpacks.stacks.resolute`
+* Run tiny: `io.buildpacks.stacks.resolute.tiny`
+* Run static: `io.buildpacks.stacks.resolute.static`
 
 ### User IDs
 

--- a/text/stacks/0010-resolute-raccoon.md
+++ b/text/stacks/0010-resolute-raccoon.md
@@ -1,0 +1,98 @@
+# Base Images based on Ubuntu 2026.04: Resolute Raccoon
+
+## Summary
+
+A set of base images based on the Ubuntu 2026.04 LTS (Resolute Raccoon) release base
+image should be developed, released, and maintained by the Stacks team. Like
+the existing noble base images, these new base images should come in "build", "run", "run-tiny", and
+"run-static" variants with similar, if not identical, sets of packages pre-installed.
+
+## Motivation
+
+Ubuntu provides a long-term-support (LTS) release every 2 years in April. These
+releases are supported by Canonical for 5 years. The current jammy base image,
+first released in April 2022, will therefore be going out of support at the end
+of April 2027. In order to ensure that Paketo continues to provide supported
+Ubuntu-based base images for our users, we should produce a new set of base images,
+based on Resolute, alongside the current Noble base images.
+
+## Detailed Explanation
+
+### Variants
+
+The Resolute base images will be delivered in 4 variants that align to those already
+offered in the Noble base images. The variants will be called `build`, `run`, `run-tiny` and
+`run-static` just as they are in the Noble base images. Each should be developed to offer
+roughly the same set of OS-level package support as their Noble equivalent.
+
+### Base image IDs
+
+Base image IDs will be given to each variant of the base images as follows:
+
+* Build: `io.buildpacks.base.images.resolute.build`
+* Run: `io.buildpacks.base.images.resolute.run`
+* Run tiny: `io.buildpacks.base.images.resolute.run.tiny`
+* Run static: `io.buildpacks.base.images.resolute.run.static`
+
+### User IDs
+
+These base images will differ from Jammy with regards to their UID definitions.
+Each variant will ensure that the UID for the `build` phase is different than
+the `run` phase. This change will align more closely with the
+[recommendations](https://github.com/buildpacks/rfcs/blob/main/text/0085-run-uid.md)
+outlined in the Buildpacks Specification.
+
+### Image Naming and Tagging
+
+The base images will name and tag their release images with the following pattern:
+
+```
+paketobuildpacks/ubuntu-resolute-{variant}:{version}
+```
+
+For example we could see the following images for Resolute base images:
+
+* `paketobuildpacks/ubuntu-resolute-build:latest`
+* `paketobuildpacks/ubuntu-resolute-run:latest`
+* `paketobuildpacks/ubuntu-resolute-run-tiny:latest`
+* `paketobuildpacks/ubuntu-resolute-run-static:latest`
+
+* `paketobuildpacks/ubuntu-resolute-build:1.2.3`
+* `paketobuildpacks/ubuntu-resolute-run:1.2.3`
+* `paketobuildpacks/ubuntu-resolute-run-tiny:1.2.3`
+* `paketobuildpacks/ubuntu-resolute-run-static:1.2.3`
+
+Each base image repository should include a README that outlines the base images that are
+available.
+
+### Mixins
+
+These base images will **NOT** include mixins declared through the
+`io.buildpacks.stack.mixins` image label. This API is being superseded in the
+upstream CNB project with this
+[RFC](https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md).
+In preparation for this, and to ensure we don't perpetuate a deprecated API,
+the Resolute base images will no longer include this label in their metadata.
+
+## Implementation
+
+After the [final release](https://documentation.ubuntu.com/release-notes/26.04/schedule/)
+date on April 23, 2026, we can release our official base images versions.
+
+### Repositories
+
+The Stacks subteam will create 1 new repo for Resolute under Paketo buildpacks organization:
+
+* `ubuntu-resolute-base-images`
+
+This repo will contain the configuration for its variant of the base images
+as well as the releases and their related artifacts.
+
+## Prior Art
+
+* [ubuntu-noble-base-images](https://github.com/paketo-buildpacks/ubuntu-noble-base-images)
+* [ubi-10-base-images](https://github.com/paketo-buildpacks/ubi-10-base-images)
+
+## Unresolved Questions and Bikeshedding
+
+* N/A

--- a/text/stacks/0010-resolute-raccoon.md
+++ b/text/stacks/0010-resolute-raccoon.md
@@ -29,10 +29,10 @@ roughly the same set of OS-level package support as their Noble equivalent.
 
 Base image IDs will be given to each variant of the base images as follows:
 
-* Build: `io.buildpacks.base.images.resolute.build`
-* Run: `io.buildpacks.base.images.resolute.run`
-* Run tiny: `io.buildpacks.base.images.resolute.run.tiny`
-* Run static: `io.buildpacks.base.images.resolute.run.static`
+* Build: `io.buildpacks.base.images.resolute`
+* Run: `io.buildpacks.base.images.resolute`
+* Run tiny: `io.buildpacks.base.images.resolute.tiny`
+* Run static: `io.buildpacks.base.images.resolute.static`
 
 ### User IDs
 

--- a/text/stacks/0010-resolute-raccoon.md
+++ b/text/stacks/0010-resolute-raccoon.md
@@ -7,6 +7,8 @@ image should be developed, released, and maintained by the Stacks team. Like
 the existing noble base images, these new base images should come in "build", "run", "run-tiny", and
 "run-static" variants with similar, if not identical, sets of packages pre-installed.
 
+If the package set is not identical, it would be due to changes in Ubuntu packages. The goal from the Paketo perspective is to have a functionally equivalent image from release to release.
+
 ## Motivation
 
 Ubuntu provides a long-term-support (LTS) release every 2 years in April. These

--- a/text/stacks/0010-resolute-raccoon.md
+++ b/text/stacks/0010-resolute-raccoon.md
@@ -6,6 +6,7 @@ A set of base images based on the Ubuntu 2026.04 LTS (Resolute Raccoon) release 
 image should be developed, released, and maintained by the Stacks team. Like
 the existing noble base images, these new base images should come in "build", "run", "run-tiny", and
 "run-static" variants with similar, if not identical, sets of packages pre-installed.
+Each variant will also be published without stack ID metadata, using a `-no-stacks` suffix on Docker Hub image names.
 
 If the package set is not identical, it would be due to changes in Ubuntu packages. The goal from the Paketo perspective is to have a functionally equivalent image from release to release.
 
@@ -36,6 +37,13 @@ Stack IDs will be given to each variant of the base images as follows:
 * Run tiny: `io.buildpacks.stacks.resolute.tiny`
 * Run static: `io.buildpacks.stacks.resolute.static`
 
+In addition to the images above, the same four variants (`build`, `run`,
+`run-tiny`, and `run-static`) will be published without any stack ID in their image metadata.
+These images are part of Paketo's effort to deprecate stacks across Paketo buildpacks. They
+are intended for use with platforms and tooling that have adopted the base image metadata
+defined in [CNB RFC 0096](https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md)
+and no longer rely on `io.buildpacks.stack.id` labels.
+
 ### User IDs
 
 These base images will differ from Jammy with regards to their UID definitions.
@@ -46,11 +54,15 @@ outlined in the Buildpacks Specification.
 
 ### Image Naming and Tagging
 
-The base images will name and tag their release images with the following pattern:
+The base images will name and tag their release images with the following patterns:
 
 ```
 paketobuildpacks/ubuntu-resolute-{variant}:{version}
+paketobuildpacks/ubuntu-resolute-{variant}-no-stacks:{version}
 ```
+
+The `-no-stacks` suffix denotes images that do not include a stack ID in their metadata, as
+described in the Stack IDs section above.
 
 For example we could see the following images for Resolute base images:
 
@@ -63,6 +75,18 @@ For example we could see the following images for Resolute base images:
 * `paketobuildpacks/ubuntu-resolute-run:1.2.3`
 * `paketobuildpacks/ubuntu-resolute-run-tiny:1.2.3`
 * `paketobuildpacks/ubuntu-resolute-run-static:1.2.3`
+
+The same variants without stack IDs will also be published with the `-no-stacks` suffix:
+
+* `paketobuildpacks/ubuntu-resolute-build-no-stacks:latest`
+* `paketobuildpacks/ubuntu-resolute-run-no-stacks:latest`
+* `paketobuildpacks/ubuntu-resolute-run-tiny-no-stacks:latest`
+* `paketobuildpacks/ubuntu-resolute-run-static-no-stacks:latest`
+
+* `paketobuildpacks/ubuntu-resolute-build-no-stacks:1.2.3`
+* `paketobuildpacks/ubuntu-resolute-run-no-stacks:1.2.3`
+* `paketobuildpacks/ubuntu-resolute-run-tiny-no-stacks:1.2.3`
+* `paketobuildpacks/ubuntu-resolute-run-static-no-stacks:1.2.3`
 
 Each base image repository should include a README that outlines the base images that are
 available.

--- a/text/stacks/README.md
+++ b/text/stacks/README.md
@@ -9,6 +9,7 @@ This directory contains RFCs that pertain to the [Stacks Subteam](https://github
 * [0007: Squash Stack Images](0007-squash-stack.md)
 * [0008: Remove Ruby from the Jammy Full Stack](0008-jammy-full-remove-ruby.md)
 * [0009: Remove `yj` from all stacks](0009-remove-yj.md)
+* [0010: Base images based on Ubuntu 2026.04: Resolute Raccoon](0010-resolute-raccoon.md)
 
 ## Implemented RFCs
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* Proposes adding Resolute Raccoon base images to paketo buildpacks

The current RFC is based on the https://github.com/paketo-buildpacks/rfcs/blob/main/text/stacks/0004-jammy-jellyfish.md 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
